### PR TITLE
Enforcing identity format '...@developer.gserviceaccount.com' correctly

### DIFF
--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
@@ -198,7 +198,7 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
    @Override
    protected Properties setupProperties() {
       Properties overrides = super.setupProperties();
-      overrides.put("google-compute-engine.identity", "myproject");
+      overrides.put("google-compute-engine.identity", "myproject@developer.gserviceaccount.com");
       try {
          overrides.put("google-compute-engine.credential", toStringAndClose(getClass().getResourceAsStream("/testpk.pem")));
       } catch (IOException e) {

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiExpectTest.java
@@ -28,7 +28,7 @@ public class BaseGoogleComputeEngineApiExpectTest extends BaseGoogleComputeEngin
    @Override
    protected Properties setupProperties() {
       Properties properties = super.setupProperties();
-      properties.put("google-compute-engine.identity", "myproject");
+      properties.put("google-compute-engine.identity", "myproject@developer.gserviceaccount.com");
       return properties;
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineExpectTest.java
@@ -73,7 +73,7 @@ public class BaseGoogleComputeEngineExpectTest<T> extends BaseRestApiExpectTest<
    private static final String header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
 
    private static final String CLAIMS_TEMPLATE = "{" +
-           "\"iss\":\"myproject\"," +
+           "\"iss\":\"myproject@developer.gserviceaccount.com\"," +
            "\"scope\":\"%s\"," +
            "\"aud\":\"https://accounts.google.com/o/oauth2/token\"," +
            "\"exp\":3600," +


### PR DESCRIPTION
Should **not** be merged until after #9.

This will have to be merged and rebased after #9 is done, but I'm pretty sure the validation that is currently _broken_ was actually intended.
