### PR TITLE
JCLOUDS-367: GCE nodes n>1 ignoring inboundPort

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.google.inject.Scopes;
 import org.jclouds.collect.Memoized;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.ComputeServiceAdapter;
@@ -46,6 +47,7 @@ import org.jclouds.googlecomputeengine.compute.GoogleComputeEngineService;
 import org.jclouds.googlecomputeengine.compute.GoogleComputeEngineServiceAdapter;
 import org.jclouds.googlecomputeengine.compute.extensions.GoogleComputeEngineSecurityGroupExtension;
 import org.jclouds.googlecomputeengine.compute.functions.BuildInstanceMetadata;
+import org.jclouds.googlecomputeengine.compute.functions.FirewallTagNamingConvention;
 import org.jclouds.googlecomputeengine.compute.functions.FirewallToIpPermission;
 import org.jclouds.googlecomputeengine.compute.functions.GoogleComputeEngineImageToImage;
 import org.jclouds.googlecomputeengine.compute.functions.InstanceInZoneToNodeMetadata;
@@ -154,6 +156,7 @@ public class GoogleComputeEngineServiceContextModule
 
       install(new LocationsFromComputeServiceAdapterModule<InstanceInZone, MachineTypeInZone, Image, Zone>() {});
 
+      bind(FirewallTagNamingConvention.Factory.class).in(Scopes.SINGLETON);
    }
 
    @Provides

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/FirewallTagNamingConvention.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/FirewallTagNamingConvention.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.compute.functions;
+
+import com.google.common.base.Predicate;
+import org.jclouds.compute.functions.GroupNamingConvention;
+
+import javax.inject.Inject;
+
+/**
+ * The convention for naming instance tags that firewall rules recognise.
+ * 
+ * @author richardcloudsoft
+ */
+public class FirewallTagNamingConvention {
+
+   public static class Factory {
+
+      private final GroupNamingConvention.Factory namingConvention;
+
+      @Inject
+      public Factory(GroupNamingConvention.Factory namingConvention) {
+         this.namingConvention = namingConvention;
+      }
+
+      public FirewallTagNamingConvention get(String groupName) {
+         return new FirewallTagNamingConvention(namingConvention.create().sharedNameForGroup(groupName));
+      }
+   }
+
+   private final String sharedResourceName;
+
+   public FirewallTagNamingConvention(String sharedResourceName) {
+      this.sharedResourceName = sharedResourceName;
+   }
+
+   public String name(int port) {
+      return String.format("%s-port-%s", sharedResourceName, port);
+   }
+
+   public Predicate<? super String> isFirewallTag() {
+      return new Predicate<String>() {
+         @Override
+         public boolean apply(String input) {
+            return input != null && input.startsWith(sharedResourceName + "-port-");
+         }
+      };
+   }
+
+}

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Firewall.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Firewall.java
@@ -250,6 +250,11 @@ public final class Firewall extends Resource {
       private final IpProtocol ipProtocol;
       private final RangeSet<Integer> ports;
 
+      /* Some handy shortcuts */
+      public static Rule permitTcpRule(Integer start, Integer end) { return Rule.builder().IpProtocol(IpProtocol.TCP).addPortRange(start, end).build(); }
+      public static Rule permitTcpRule(Integer port) { return Rule.builder().IpProtocol(IpProtocol.TCP).addPort(port).build(); }
+      public static Rule permitUdpRule(Integer start, Integer end) { return Rule.builder().IpProtocol(IpProtocol.UDP).addPortRange(start, end).build(); }
+      public static Rule permitUdpRule(Integer port) { return Rule.builder().IpProtocol(IpProtocol.UDP).addPort(port).build(); }
       @ConstructorProperties({
               "IpProtocol", "ports"
       })

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
@@ -269,6 +269,26 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .addHeader("Accept", "application/json")
               .addHeader("Authorization", "Bearer " + TOKEN).build();
 
+      HttpRequest getNetworkRequest = HttpRequest.builder()
+              .method("GET")
+              .endpoint("https://www.googleapis" +
+                      ".com/compute/v1beta16/projects/myproject/global/networks/jclouds-test-delete")
+              .addHeader("Accept", "application/json")
+              .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+      HttpResponse getNetworkResponse = HttpResponse.builder().statusCode(200)
+              .payload(staticPayloadFromResource("/GoogleComputeEngineServiceExpectTest/network_get.json")).build();
+   
+      HttpRequest listFirewallsRequest = HttpRequest.builder()
+              .method("GET")
+              .endpoint("https://www.googleapis" +
+                      ".com/compute/v1beta16/projects/myproject/global/firewalls")
+              .addHeader("Accept", "application/json")
+              .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+      HttpResponse listFirewallsResponse = HttpResponse.builder().statusCode(200)
+              .payload(staticPayloadFromResource("/GoogleComputeEngineServiceExpectTest/firewall_list.json")).build();
+      
       HttpRequest deleteNetworkReqquest = HttpRequest.builder()
               .method("DELETE")
               .endpoint("https://www.googleapis" +
@@ -289,6 +309,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(GET_ZONE_OPERATION_REQUEST)
               .add(getInstanceRequestForInstance("test-delete-networks"))
               .add(LIST_INSTANCES_REQUEST)
+              .add(getNetworkRequest)
+              .add(listFirewallsRequest)
               .add(deleteFirewallRequest)
               .add(GET_GLOBAL_OPERATION_REQUEST)
               .add(deleteNetworkReqquest)
@@ -313,6 +335,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(getListInstancesResponseForSingleInstanceAndNetworkAndStatus("test-delete-networks",
                       "test-network", Instance
                       .Status.TERMINATED.name()))
+              .add(getNetworkResponse)
+              .add(listFirewallsResponse)
               .add(SUCESSFULL_OPERATION_RESPONSE)
               .add(GET_GLOBAL_OPERATION_RESPONSE)
               .add(SUCESSFULL_OPERATION_RESPONSE)
@@ -363,6 +387,38 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
       HttpResponse getInstanceResponse = HttpResponse.builder().statusCode(200)
               .payload(payloadFromStringWithContentType(payload, "application/json")).build();
 
+      HttpRequest getFirewallRequest = HttpRequest
+                 .builder()
+                 .method("GET")
+                 .endpoint("https://www.googleapis" +
+                         ".com/compute/v1beta16/projects/myproject/global/firewalls/jclouds-test-port-22")
+                 .addHeader("Accept", "application/json")
+                 .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+      HttpRequest insertFirewallRequest = HttpRequest
+                 .builder()
+                 .method("POST")
+                 .endpoint("https://www.googleapis.com/compute/v1beta16/projects/myproject/global/firewalls")
+                 .addHeader("Accept", "application/json")
+                 .addHeader("Authorization", "Bearer " + TOKEN)
+                 .payload(payloadFromStringWithContentType("{\"name\":\"jclouds-test-port-22\",\"network\":\"https://www.googleapis" +
+                         ".com/compute/v1beta16/projects/myproject/global/networks/jclouds-test\"," +
+                         "\"sourceRanges\":[\"10.0.0.0/8\",\"0.0.0.0/0\"],\"sourceTags\":[\"aTag\"],\"targetTags\":[\"jclouds-test-port-22\"],\"allowed\":[{\"IPProtocol\":\"tcp\"," +
+                         "\"ports\":[\"22\"]}," +
+                         "{\"IPProtocol\":\"udp\",\"ports\":[\"22\"]}]}",
+                         MediaType.APPLICATION_JSON))
+                 .build();
+
+      HttpRequest setTagsRequest = HttpRequest
+                 .builder()
+                 .method("POST")
+                 .endpoint("https://www.googleapis.com/compute/v1beta16/projects/myproject/zones/us-central1-a/instances/test-1/setTags")
+                 .addHeader("Accept", "application/json")
+                 .addHeader("Authorization", "Bearer " + TOKEN)
+                 .payload(payloadFromStringWithContentType("{\"items\":[\"jclouds-test-port-22\"],\"fingerprint\":\"abcd\"}",
+                         MediaType.APPLICATION_JSON))
+                 .build();
+      
       List<HttpRequest> orderedRequests = ImmutableList.<HttpRequest>builder()
               .add(requestForScopes(COMPUTE_READONLY_SCOPE))
               .add(GET_PROJECT_REQUEST)
@@ -377,8 +433,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(INSERT_NETWORK_REQUEST)
               .add(GET_GLOBAL_OPERATION_REQUEST)
               .add(GET_NETWORK_REQUEST)
-              .add(GET_FIREWALL_REQUEST)
-              .add(INSERT_FIREWALL_REQUEST)
+              .add(getFirewallRequest)
+              .add(insertFirewallRequest)
               .add(GET_GLOBAL_OPERATION_REQUEST)
               .add(LIST_INSTANCES_REQUEST)
               .add(LIST_PROJECT_IMAGES_REQUEST)
@@ -390,6 +446,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(SET_TAGS_REQUEST)
               .add(GET_ZONE_OPERATION_REQUEST)
               .add(getInstanceRequestForInstance("test-1"))
+              .add(setTagsRequest)
+              .add(setTagsRequest)
               .build();
 
       List<HttpResponse> orderedResponses = ImmutableList.<HttpResponse>builder()
@@ -419,6 +477,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(SET_TAGS_RESPONSE)
               .add(GET_ZONE_OPERATION_RESPONSE)
               .add(getInstanceResponse)
+              .add(SUCESSFULL_OPERATION_RESPONSE)
+              .add(SUCESSFULL_OPERATION_RESPONSE)
               .build();
 
 

--- a/google-compute-engine/src/test/resources/GoogleComputeEngineServiceExpectTest/firewall_list.json
+++ b/google-compute-engine/src/test/resources/GoogleComputeEngineServiceExpectTest/firewall_list.json
@@ -1,0 +1,37 @@
+{
+   "kind": "compute#firewallList",
+   "id": "projects/google/firewalls",
+   "selfLink": "https://www.googleapis.com/compute/v1beta16/projects/google/global/firewalls",
+   "items": [
+      {
+
+         "kind": "compute#firewall",
+         "id": "12862241031274216284",
+         "creationTimestamp": "2012-04-13T03:05:02.855",
+         "selfLink": "https://www.googleapis.com/compute/v1beta16/projects/myproject/global/firewalls/jclouds-test-delete",
+         "name": "jclouds-test-delete",
+         "description": "Internal traffic from default allowed",
+         "network": "https://www.googleapis.com/compute/v1beta16/projects/myproject/global/networks/jclouds-test-delete",
+         "sourceRanges": [
+            "10.0.0.0/8"
+         ],
+         "allowed": [
+            {
+               "IPProtocol": "tcp",
+               "ports": [
+                  "1-65535"
+               ]
+            },
+            {
+               "IPProtocol": "udp",
+               "ports": [
+                  "1-65535"
+               ]
+            },
+            {
+               "IPProtocol": "icmp"
+            }
+         ]
+      }
+   ]
+}

--- a/google-compute-engine/src/test/resources/GoogleComputeEngineServiceExpectTest/network_get.json
+++ b/google-compute-engine/src/test/resources/GoogleComputeEngineServiceExpectTest/network_get.json
@@ -1,0 +1,10 @@
+{
+   "kind": "compute#network",
+   "id": "13024414170909937976",
+   "creationTimestamp": "2012-10-24T20:13:19.967",
+   "selfLink": "https://www.googleapis.com/compute/v1beta16/projects/myproject/global/networks/jclouds-test-delete",
+   "name": "jclouds-test-delete",
+   "description": "Default network for the project",
+   "IPv4Range": "10.0.0.0/8",
+   "gatewayIPv4": "10.0.0.1"
+}


### PR DESCRIPTION
The inboundPort settings of the first node in the group dictated the firewall configuration. Subsequent nodes added to the group had their inboundPort settings ignored.

GCE firewalls specify their "target" (VM instances) by means of tags - if a targetTag on a firewall matches the tag on an instance, the firewall's rules are allowed for the instance. This commit applies a tag for each requested inboundPort to new instances. Then, a firewall is created for each tag (if one does not already exist) which has 'allow' rules for the port.
