### PR TITLE
Fix Live Tests for JCLOUDS-360 which rely on platform-dep nanoseconds

### DIFF
--- a/oauth/src/test/java/org/jclouds/oauth/v2/internal/BaseOAuthApiLiveTest.java
+++ b/oauth/src/test/java/org/jclouds/oauth/v2/internal/BaseOAuthApiLiveTest.java
@@ -29,8 +29,6 @@ import org.jclouds.apis.BaseApiLiveTest;
 import org.jclouds.oauth.v2.OAuthApi;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Ticker;
-
 
 /**
  * @author David Alves
@@ -54,7 +52,7 @@ public class BaseOAuthApiLiveTest extends BaseApiLiveTest<OAuthApi> {
    }
 
    protected long nowInSeconds() {
-      return TimeUnit.SECONDS.convert(Ticker.systemTicker().read(), TimeUnit.NANOSECONDS);
+      return TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
    }
 
 }

--- a/oauth/src/test/java/org/jclouds/oauth/v2/internal/BaseOAuthAuthenticatedApiLiveTest.java
+++ b/oauth/src/test/java/org/jclouds/oauth/v2/internal/BaseOAuthAuthenticatedApiLiveTest.java
@@ -17,7 +17,7 @@
 package org.jclouds.oauth.v2.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.oauth.v2.config.OAuthProperties.AUDIENCE;
 import static org.jclouds.oauth.v2.config.OAuthProperties.SIGNATURE_OR_MAC_ALGORITHM;
@@ -37,7 +37,6 @@ import org.jclouds.oauth.v2.domain.TokenRequest;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
-import com.google.common.base.Ticker;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -80,7 +79,7 @@ public abstract class BaseOAuthAuthenticatedApiLiveTest<A extends Closeable> ext
 
       Header header = Header.builder().signerAlgorithm(signatureAlgorithm).type("JWT").build();
 
-      long now = SECONDS.convert(Ticker.systemTicker().read(), NANOSECONDS);
+      long now = SECONDS.convert(System.currentTimeMillis(), MILLISECONDS);
 
       ClaimSet claimSet = ClaimSet.builder()
                                   .addClaim("aud", audience)


### PR DESCRIPTION
This addresses the same issue that was fixed with PR #7 but for the live tests.

(FWIW, I have a signed Apache ICLA on file)
