### PR TITLE
JCLOUDS-643: Fix Google and OAuth tests

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <test.google-cloud-storage.identity>  Email_Address_Associated_With_Service_Account</test.google-cloud-storage.identity>
     <test.google-cloud-storage.credential>Private_Key_Associated__With_Service Account</test.google-cloud-storage.credential>
+    <test.google-cloud-storage.project-number>The Account Project number</test.google-cloud-storage.project-number>
     <test.google-cloud-storage.api-version>v1</test.google-cloud-storage.api-version>
     <test.google-cloud-storage.build-version />
   </properties>
@@ -99,6 +100,12 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <executions>
+              <execution>
+                <id>default-test</id>
+                <configuration>
+                  <skipTests>true</skipTests>
+                </configuration>
+              </execution>
               <execution>
                 <id>integration</id>
                 <phase>integration-test</phase>

--- a/google-compute-engine/pom.xml
+++ b/google-compute-engine/pom.xml
@@ -108,6 +108,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <execution>
+                                <id>default-test</id>
+                                <configuration>
+                                    <skipTests>true</skipTests>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>integration</id>
                                 <phase>integration-test</phase>
                                 <goals>

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineApiMetadata.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineApiMetadata.java
@@ -63,8 +63,7 @@ public class GoogleComputeEngineApiMetadata extends BaseHttpApiMetadata<GoogleCo
       properties.put(AUDIENCE, "https://accounts.google.com/o/oauth2/token");
       properties.put(SIGNATURE_OR_MAC_ALGORITHM, "RS256");
       properties.put(PROPERTY_SESSION_INTERVAL, 3600);
-      properties.setProperty(TEMPLATE, "osFamily=GCEL,osVersionMatches=1[012].[01][04],locationId=us-central1-a," +
-              "loginUser=jclouds");
+      properties.setProperty(TEMPLATE, "osFamily=DEBIAN,osVersionMatches=7\\..*,locationId=us-central1-a,loginUser=jclouds");
       properties.put(OPERATION_COMPLETE_INTERVAL, 500);
       properties.put(OPERATION_COMPLETE_TIMEOUT, 600000);
       return properties;

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
@@ -183,7 +183,7 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .builder()
               .method("POST")
               .endpoint("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/disks"
-                                + "?sourceImage=https%3A//www.googleapis.com/compute/v1/projects/centos-cloud/global/images/gcel-12-04-v20121106")
+                                + "?sourceImage=https%3A//www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718")
               .addHeader("Accept", "application/json")
               .addHeader("Authorization", "Bearer " + TOKEN)
               .payload(payloadFromStringWithContentType("{\"name\":\"" + instanceName + "-" + GCE_BOOT_DISK_SUFFIX + "\","
@@ -226,7 +226,7 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
                                                         "\"value\":\"jclouds:" +
                                                         publicKey + " jclouds@localhost\"},{\"key\":\"jclouds-group\"," +
                                                         "\"value\":\"" + groupName + "\"},{\"key\":\"jclouds-image\",\"value\":\"https://www.googleapis" +
-                                                        ".com/compute/v1/projects/centos-cloud/global/images/gcel-12-04-v20121106\"}," +
+                                                        ".com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718\"}," +
                                                         "{\"key\":\"jclouds-delete-boot-disk\",\"value\":\"true\"}]}}",
                                                         MediaType.APPLICATION_JSON)).build();
    }
@@ -568,7 +568,7 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
       GoogleComputeEngineTemplateOptions options = computeService.templateOptions().as(GoogleComputeEngineTemplateOptions.class);
       options.tags(ImmutableSet.of("aTag"));
       NodeMetadata node = getOnlyElement(computeService.createNodesInGroup("test", 1, options));
-      assertEquals(node.getImageId(), "gcel-12-04-v20121106");
+      assertEquals(node.getImageId(), "debian-7-wheezy-v20140718");
    }
 }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceLiveTest.java
@@ -17,7 +17,7 @@
 package org.jclouds.googlecomputeengine.compute;
 
 import static com.google.common.collect.Iterables.contains;
-import static org.jclouds.oauth.v2.OAuthTestUtils.setCredentialFromPemFile;
+import static org.jclouds.oauth.v2.OAuthTestUtils.setCredential;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import java.util.Properties;
@@ -51,7 +51,7 @@ public class GoogleComputeEngineServiceLiveTest extends BaseComputeServiceLiveTe
    @Override
    protected Properties setupProperties() {
       Properties props = super.setupProperties();
-      setCredentialFromPemFile(props, provider + ".credential");
+      setCredential(props, provider + ".credential");
       return props;
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/InstanceInZoneToNodeMetadataTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/InstanceInZoneToNodeMetadataTest.java
@@ -158,7 +158,7 @@ public class InstanceInZoneToNodeMetadataTest {
          .metadata(Metadata.builder()
                .items(ImmutableMap.of("aKey", "aValue",
                   "jclouds-image",
-                  "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/gcel-12-04-v20121106",
+                  "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718",
                   "jclouds-delete-boot-disk", "true"))
                .fingerprint("efgh")
                .build())
@@ -167,8 +167,7 @@ public class InstanceInZoneToNodeMetadataTest {
 
       images = ImmutableSet.of(new ImageBuilder()
          .id("1")
-         .uri(URI.create("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/"
-               + "gcel-12-04-v20121106"))
+         .uri(URI.create("https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718"))
          .providerId("1")
          .name("mock image")
          .status(AVAILABLE)

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/FirewallApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/FirewallApiLiveTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
+@Test(groups = "live", testName = "FirewallApiLiveTest")
 public class FirewallApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    private static final String FIREWALL_NAME = "firewall-api-live-test-firewall";

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiExpectTest.java
@@ -52,7 +52,7 @@ public class ImageApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
            .addHeader("Authorization", "Bearer " + TOKEN).build();
 
    public static final HttpResponse LIST_CENTOS_IMAGES_RESPONSE = HttpResponse.builder().statusCode(200)
-           .payload(staticPayloadFromResource("/image_list_single_page.json")).build();
+         .payload(staticPayloadFromResource("/image_list_centos.json")).build();
 
    public static final HttpRequest LIST_DEBIAN_IMAGES_REQUEST = HttpRequest
            .builder()
@@ -63,7 +63,7 @@ public class ImageApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
 
    public static final HttpResponse LIST_DEBIAN_IMAGES_RESPONSE =
       HttpResponse.builder().statusCode(200)
-                  .payload(staticPayloadFromResource("/image_list_empty.json")).build();
+            .payload(staticPayloadFromResource("/image_list_debian.json")).build();
 
    public void testGetImageResponseIs2xx() throws Exception {
       HttpRequest get = HttpRequest

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Module;
 
+@Test(groups = "live", testName = "InstanceApiLiveTest")
 public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    private static final String INSTANCE_NETWORK_NAME = "instance-api-live-test-network";

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/NetworkApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/NetworkApiLiveTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+@Test(groups = "live", testName = "NetworkApiLiveTest")
 public class NetworkApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    private static final String NETWORK_NAME = "network-api-live-test-network";

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RouteApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RouteApiLiveTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+@Test(groups = "live", testName = "RouteApiLiveTest")
 public class RouteApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    private static final String DEST_RANGE = "20.10.0.0/16";

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceTest.java
@@ -71,7 +71,7 @@ public class ParseInstanceTest extends BaseGoogleComputeEngineParseTest<Instance
               .metadata(Metadata.builder()
                       .items(ImmutableMap.of("aKey", "aValue",
                                              "jclouds-image",
-                                             "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/gcel-12-04-v20121106",
+                                             "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718",
                                              "jclouds-delete-boot-disk", "true"))
                       .fingerprint("efgh")
                       .build())

--- a/google-compute-engine/src/test/resources/image_list_centos.json
+++ b/google-compute-engine/src/test/resources/image_list_centos.json
@@ -1,0 +1,183 @@
+{
+    "kind": "compute#imageList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images",
+    "id": "projects/centos-cloud/global/images",
+    "items": [
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20131120",
+            "id": "11748647391859510935",
+            "creationTimestamp": "2013-11-25T15:13:50.611-08:00",
+            "name": "centos-6-v20131120",
+            "description": "SCSI-enabled CentOS 6 built on 2013-11-20",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140318"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "269993565",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140318",
+            "id": "11743140967858608122",
+            "creationTimestamp": "2014-03-19T15:01:13.388-07:00",
+            "name": "centos-6-v20140318",
+            "description": "CentOS 6.5 x86_64 built on 2014-03-18",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140408"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "341230444",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140408",
+            "id": "18033188469723077298",
+            "creationTimestamp": "2014-04-09T10:31:57.518-07:00",
+            "name": "centos-6-v20140408",
+            "description": "CentOS 6.5 x86_64 built on 2014-04-08",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140415"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "342252847",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140415",
+            "id": "10463166969914166288",
+            "creationTimestamp": "2014-04-22T12:05:16.927-07:00",
+            "name": "centos-6-v20140415",
+            "description": "CentOS 6.5 x86_64 built on 2014-04-15",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140522"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1026663807",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140522",
+            "id": "14390164727436022001",
+            "creationTimestamp": "2014-06-03T10:21:42.109-07:00",
+            "name": "centos-6-v20140522",
+            "description": "CentOS 6.5 x86_64 built on 2014-05-22",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140606"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1028292810",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140605",
+            "id": "16310166269920012092",
+            "creationTimestamp": "2014-06-05T11:04:45.767-07:00",
+            "name": "centos-6-v20140605",
+            "description": "CentOS 6.5 x86_64 built on 2014-06-05",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140606"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1028745777",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140606",
+            "id": "6290630306542078308",
+            "creationTimestamp": "2014-06-06T13:16:42.265-07:00",
+            "name": "centos-6-v20140606",
+            "description": "CentOS 6.5 x86_64 built on 2014-06-06",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140619"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1028757792",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140619",
+            "id": "3614861379648377676",
+            "creationTimestamp": "2014-06-24T13:28:11.552-07:00",
+            "name": "centos-6-v20140619",
+            "description": "CentOS 6.5 x86_64 built on 2014-06-19",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140718"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1029860991",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140718",
+            "id": "16259951858818091437",
+            "creationTimestamp": "2014-07-24T09:02:18.298-07:00",
+            "name": "centos-6-v20140718",
+            "description": "CentOS 6.5 x86_64 built on 2014-07-18",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1031630715",
+            "diskSizeGb": "10"
+        }
+    ]
+}

--- a/google-compute-engine/src/test/resources/image_list_debian.json
+++ b/google-compute-engine/src/test/resources/image_list_debian.json
@@ -1,0 +1,400 @@
+{
+    "kind": "compute#imageList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images",
+    "id": "projects/debian-cloud/global/images",
+    "items": [
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20131127",
+            "id": "12371298324486102144",
+            "creationTimestamp": "2013-12-02T17:49:01.206-08:00",
+            "name": "backports-debian-7-wheezy-v20131127",
+            "description": "Debian GNU/Linux 7.2 (wheezy) with backports kernel built on 2013-11-27",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140318"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "365056004",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140318",
+            "id": "4359542978415320596",
+            "creationTimestamp": "2014-03-19T14:59:48.212-07:00",
+            "name": "backports-debian-7-wheezy-v20140318",
+            "description": "Debian GNU/Linux 7.4 (wheezy) amd64 with backports kernel built on 2014-03-18",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140331"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "363791902",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140331",
+            "id": "15835408046770346721",
+            "creationTimestamp": "2014-04-02T13:22:10.344-07:00",
+            "name": "backports-debian-7-wheezy-v20140331",
+            "description": "Debian GNU/Linux 7.4 (wheezy) amd64 with backports kernel and SSH packages built on 2014-03-31",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140408"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "442398181",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140408",
+            "id": "11347897274148340677",
+            "creationTimestamp": "2014-04-09T10:34:36.072-07:00",
+            "name": "backports-debian-7-wheezy-v20140408",
+            "description": "Debian GNU/Linux 7.4 (wheezy) amd64 with backports kernel and SSH packages built on 2014-04-08",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140415"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "460293681",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140415",
+            "id": "1961353585117201359",
+            "creationTimestamp": "2014-04-22T12:05:21.799-07:00",
+            "name": "backports-debian-7-wheezy-v20140415",
+            "description": "Debian GNU/Linux 7.4 (wheezy) amd64 with backports kernel and SSH packages built on 2014-04-15",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140522"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1305361944",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140522",
+            "id": "9086860851120583043",
+            "creationTimestamp": "2014-06-03T10:22:40.439-07:00",
+            "name": "backports-debian-7-wheezy-v20140522",
+            "description": "Debian GNU/Linux 7.5 (wheezy) amd64 with backports kernel and SSH packages built on 2014-05-22",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140606"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1291544127",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140605",
+            "id": "3162880700849242534",
+            "creationTimestamp": "2014-06-05T11:15:06.942-07:00",
+            "name": "backports-debian-7-wheezy-v20140605",
+            "description": "Debian GNU/Linux 7.5 (wheezy) amd64 with backports kernel and SSH packages built on 2014-06-05",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140606"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1342678611",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140606",
+            "id": "10385475893990329896",
+            "creationTimestamp": "2014-06-06T13:16:42.088-07:00",
+            "name": "backports-debian-7-wheezy-v20140606",
+            "description": "Debian GNU/Linux 7.5 (wheezy) amd64 with backports kernel and SSH packages built on 2014-06-06",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140619"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1356729999",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140619",
+            "id": "15689321734978914353",
+            "creationTimestamp": "2014-06-24T13:29:10.490-07:00",
+            "name": "backports-debian-7-wheezy-v20140619",
+            "description": "Debian GNU/Linux 7.5 (wheezy) amd64 with backports kernel and SSH packages built on 2014-06-19",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140718"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1281043596",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140718",
+            "id": "12577251946941921963",
+            "creationTimestamp": "2014-07-24T09:10:05.365-07:00",
+            "name": "backports-debian-7-wheezy-v20140718",
+            "description": "Debian GNU/Linux 7.6 (wheezy) amd64 with backports kernel and SSH packages built on 2014-07-18",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1335987075",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131014",
+            "id": "2768298251193329825",
+            "creationTimestamp": "2013-10-28T13:52:08.233-07:00",
+            "name": "debian-7-wheezy-v20131014",
+            "description": "Debian GNU/Linux 7.2 (wheezy) built on 2013-10-14",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131120",
+                "deprecated": "2013-12-02T12:00:00Z"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "405683884",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131120",
+            "id": "17312518942796567788",
+            "creationTimestamp": "2013-11-25T15:17:00.436-08:00",
+            "name": "debian-7-wheezy-v20131120",
+            "description": "Debian GNU/Linux 7.2 (wheezy) built on 2013-11-20",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140318"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "341857472",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140318",
+            "id": "17164003659829548087",
+            "creationTimestamp": "2014-03-19T15:00:34.317-07:00",
+            "name": "debian-7-wheezy-v20140318",
+            "description": "Debian GNU/Linux 7.4 (wheezy) amd64 built on 2014-03-18",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140408"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "357365652",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140408",
+            "id": "5009074516965108296",
+            "creationTimestamp": "2014-04-09T10:32:46.862-07:00",
+            "name": "debian-7-wheezy-v20140408",
+            "description": "Debian GNU/Linux 7.4 (wheezy) amd64 built on 2014-04-08",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140415"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "387525228",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140415",
+            "id": "17362901286054305778",
+            "creationTimestamp": "2014-04-22T12:05:19.303-07:00",
+            "name": "debian-7-wheezy-v20140415",
+            "description": "Debian GNU/Linux 7.4 (wheezy) amd64 built on 2014-04-15",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140522"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1151530332",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140522",
+            "id": "5741466168076626639",
+            "creationTimestamp": "2014-06-03T10:22:05.775-07:00",
+            "name": "debian-7-wheezy-v20140522",
+            "description": "Debian GNU/Linux 7.5 (wheezy) amd64 built on 2014-05-22",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140606"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1129290498",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140605",
+            "id": "15036511115619902874",
+            "creationTimestamp": "2014-06-05T11:10:23.037-07:00",
+            "name": "debian-7-wheezy-v20140605",
+            "description": "Debian GNU/Linux 7.5 (wheezy) amd64 built on 2014-06-05",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140606"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1064425338",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140606",
+            "id": "16280724435269635469",
+            "creationTimestamp": "2014-06-06T13:16:42.897-07:00",
+            "name": "debian-7-wheezy-v20140606",
+            "description": "Debian GNU/Linux 7.5 (wheezy) amd64 built on 2014-06-06",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140619"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1108438332",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140619",
+            "id": "15990799122418306096",
+            "creationTimestamp": "2014-06-24T13:28:42.697-07:00",
+            "name": "debian-7-wheezy-v20140619",
+            "description": "Debian GNU/Linux 7.5 (wheezy) amd64 built on 2014-06-19",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "deprecated": {
+                "state": "DEPRECATED",
+                "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1158839577",
+            "diskSizeGb": "10"
+        },
+        {
+            "kind": "compute#image",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718",
+            "id": "11535450626613878896",
+            "creationTimestamp": "2014-07-24T09:06:16.694-07:00",
+            "name": "debian-7-wheezy-v20140718",
+            "description": "Debian GNU/Linux 7.6 (wheezy) amd64 built on 2014-07-18",
+            "sourceType": "RAW",
+            "rawDisk": {
+                "source": "",
+                "containerType": "TAR"
+            },
+            "status": "READY",
+            "archiveSizeBytes": "1195066695",
+            "diskSizeGb": "10"
+        }
+    ]
+}

--- a/google-compute-engine/src/test/resources/image_list_single_page.json
+++ b/google-compute-engine/src/test/resources/image_list_single_page.json
@@ -20,8 +20,8 @@
          "kind": "compute#image",
          "id": "13037721421359523565",
          "creationTimestamp": "2012-11-09T11:40:51.994-08:00",
-         "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/gcel-12-04-v20121106",
-         "name": "gcel-12-04-v20121106",
+         "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718",
+         "name": "debian-7-wheezy-v20140718",
          "description": "SCSI-enabled GCEL 12.04 LTS; Created Tue, 06 Nov 2012 00:00:00 +0000",
          "sourceType": "RAW",
          "rawDisk": {

--- a/google-compute-engine/src/test/resources/instance_get.json
+++ b/google-compute-engine/src/test/resources/instance_get.json
@@ -44,7 +44,7 @@
          },
          {
             "key": "jclouds-image",
-            "value": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/gcel-12-04-v20121106"
+            "value": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718"
          },
          {
             "key": "jclouds-delete-boot-disk",

--- a/google-compute-engine/src/test/resources/instance_list.json
+++ b/google-compute-engine/src/test/resources/instance_list.json
@@ -49,7 +49,7 @@
                },
                {
                   "key": "jclouds-image",
-                  "value": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/gcel-12-04-v20121106"
+                  "value": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718"
                },
                {
                   "key": "jclouds-delete-boot-disk",

--- a/oauth/pom.xml
+++ b/oauth/pom.xml
@@ -93,6 +93,12 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <executions>
               <execution>
+                <id>default-test</id>
+                <configuration>
+                  <skipTests>true</skipTests>
+                </configuration>
+              </execution>
+              <execution>
                 <id>integration</id>
                 <phase>integration-test</phase>
                 <goals>
@@ -105,7 +111,7 @@
                     <test.oauth.endpoint>${test.oauth.endpoint}</test.oauth.endpoint>
                     <test.oauth.api-version>${test.oauth.api-version}</test.oauth.api-version>
                     <test.oauth.build-version>${test.oauth.build-version}</test.oauth.build-version>
-                    <test.jclouds.oauth.signature-or-mac-algorithm>${test.jclouds.oauth.signature-or-mac-algorithm&gt;}</test.jclouds.oauth.signature-or-mac-algorithm>
+                    <test.jclouds.oauth.signature-or-mac-algorithm>${test.jclouds.oauth.signature-or-mac-algorithm}</test.jclouds.oauth.signature-or-mac-algorithm>
                     <test.jclouds.oauth.audience>${test.jclouds.oauth.audience}</test.jclouds.oauth.audience>
                     <test.jclouds.oauth.scopes>${test.jclouds.oauth.scopes}</test.jclouds.oauth.scopes>
                   </systemPropertyVariables>

--- a/oauth/src/test/java/org/jclouds/oauth/v2/OAuthTestUtils.java
+++ b/oauth/src/test/java/org/jclouds/oauth/v2/OAuthTestUtils.java
@@ -46,7 +46,7 @@ public class OAuthTestUtils {
       }
    }
 
-   public static String setCredentialFromPemFile(Properties overrides, String key) {
+   public static String setCredential(Properties overrides, String key) {
       String val = null;
       String credentialFromFile = null;
       String testKey = "test." + key;
@@ -54,7 +54,11 @@ public class OAuthTestUtils {
       if (System.getProperties().containsKey(testKey)) {
          val = System.getProperty(testKey);
       }
-      checkNotNull(val, String.format("the property %s must be set (pem private key path)", testKey));
+      checkNotNull(val, String.format("the property %s must be set (pem private key file path or private key as a string)", testKey));
+
+      if (val.startsWith("-----BEGIN")) {
+         return val;
+      }
 
       try {
          credentialFromFile = Files.toString(new File(val), Charsets.UTF_8);

--- a/oauth/src/test/java/org/jclouds/oauth/v2/internal/BaseOAuthApiLiveTest.java
+++ b/oauth/src/test/java/org/jclouds/oauth/v2/internal/BaseOAuthApiLiveTest.java
@@ -17,7 +17,7 @@
 package org.jclouds.oauth.v2.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.oauth.v2.OAuthTestUtils.setCredentialFromPemFile;
+import static org.jclouds.oauth.v2.OAuthTestUtils.setCredential;
 import static org.jclouds.oauth.v2.config.OAuthProperties.AUDIENCE;
 import static org.jclouds.oauth.v2.config.OAuthProperties.SCOPES;
 import static org.jclouds.oauth.v2.config.OAuthProperties.SIGNATURE_OR_MAC_ALGORITHM;
@@ -40,7 +40,7 @@ public class BaseOAuthApiLiveTest extends BaseApiLiveTest<OAuthApi> {
    @Override
    protected Properties setupProperties() {
       Properties props = super.setupProperties();
-      setCredentialFromPemFile(props, "oauth.credential");
+      setCredential(props, "oauth.credential");
       checkNotNull(setIfTestSystemPropertyPresent(props, "oauth.endpoint"), "test.oauth.endpoint must be set");
       checkNotNull(setIfTestSystemPropertyPresent(props, AUDIENCE), "test.jclouds.oauth.audience must be set");
       setIfTestSystemPropertyPresent(props, SCOPES);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCLOUDS-643

This PR fixes failing live tests and updates static data for expect tests to match.  GCEL images are depracated, so this also update the default template options to use the Debian image as recommended by Google.  Added @Test annotations to several test classes which helps testng control threading, and avoid hitting network quota limits. Several other minor fixes to make unit and live tests run more consistently.
