### PR TITLE
JCLOUDS-458:Multipart Related Upload

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -90,6 +90,12 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.6.1</version>
+      <scope>test</scope>
+    </dependency>    
   </dependencies>
   <profiles>
     <profile>

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/binders/MultipartUploadBinder.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/binders/MultipartUploadBinder.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecloudstorage.binders;
+
+import java.util.Map;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.googlecloudstorage.domain.templates.ObjectTemplate;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.io.Payload;
+import org.jclouds.io.Payloads;
+import org.jclouds.io.payloads.MultipartForm;
+import org.jclouds.io.payloads.Part;
+import org.jclouds.io.payloads.StringPayload;
+import org.jclouds.rest.MapBinder;
+
+import com.google.gson.Gson;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class MultipartUploadBinder implements MapBinder {
+
+   private final String BOUNDARY_HEADER = "multipart_boundary";
+
+   @Override
+   public <R extends HttpRequest> R bindToRequest(R request, Map<String, Object> postParams)
+            throws IllegalArgumentException {
+
+      ObjectTemplate template = (ObjectTemplate) postParams.get("template");
+      Payload payload = (Payload) postParams.get("payload");
+
+      String contentType = checkNotNull(template.getContentType(), "contentType");
+      Long length = checkNotNull(template.getSize(), "contetLength");
+
+      StringPayload jsonPayload = Payloads.newStringPayload(new Gson().toJson(template));
+
+      payload.getContentMetadata().setContentLength(length);
+
+      Part jsonPart = Part.create("Metadata", jsonPayload,
+               new Part.PartOptions().contentType(MediaType.APPLICATION_JSON));
+      Part mediaPart = Part.create(template.getName(), payload, new Part.PartOptions().contentType(contentType));
+
+      MultipartForm compPayload = new MultipartForm(BOUNDARY_HEADER, jsonPart, mediaPart);
+      request.setPayload(compPayload);
+      // HeaderPart
+      request.toBuilder().replaceHeader(HttpHeaders.CONTENT_TYPE, "Multipart/related; boundary= " + BOUNDARY_HEADER)
+               .build();
+      return request;
+   }
+
+   @Override
+   public <R extends HttpRequest> R bindToRequest(R request, Object input) {
+      return request;
+   }
+}

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
@@ -35,6 +35,7 @@ import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.Fallbacks.TrueOnNotFoundOr404;
 import org.jclouds.googlecloudstorage.binders.ComposeObjectBinder;
+import org.jclouds.googlecloudstorage.binders.MultipartUploadBinder;
 import org.jclouds.googlecloudstorage.binders.UploadBinder;
 import org.jclouds.googlecloudstorage.domain.GCSObject;
 import org.jclouds.googlecloudstorage.domain.ListPage;
@@ -458,5 +459,28 @@ public interface ObjectApi {
    GCSObject copyObject(@PathParam("destinationBucket") String destinationBucket,
             @PathParam("destinationObject") String destinationObject, @PathParam("sourceBucket") String sourceBucket,
             @PathParam("sourceObject") String sourceObject, CopyObjectOptions options);
+
+   /**
+    * Stores a new object with metadata.
+    *
+    * @see https://developers.google.com/storage/docs/json_api/v1/how-tos/upload#multipart
+    *
+    * @param bucketName
+    *           Name of the bucket in which the object to be stored
+    * @param objectTemplate
+    *           Supply an {@link ObjectTemplate}.
+    *
+    * @return a {@link GCSObject}
+    */
+  
+   @Named("Object:multipartUpload")
+   @POST
+   @QueryParams(keys = "uploadType", values = "multipart")
+   @Consumes(MediaType.APPLICATION_JSON)
+   @Path("/upload/storage/v1/b/{bucket}/o")
+   @OAuthScopes(STORAGE_FULLCONTROL_SCOPE)
+   @MapBinder(MultipartUploadBinder.class)
+   GCSObject multipartUpload(@PathParam("bucket") String bucketName,
+            @PayloadParam("template") ObjectTemplate objectTemplate, @PayloadParam("payload") Payload payload);
 
 }


### PR DESCRIPTION
"If you have metadata that you want to send along with the data to upload, you can make a single multipart/related request. As with simple, media-only requests, this is a good choice if the data you are sending is small enough to upload again in its entirety if the connection fails."
