### PR TITLE
JCLOUDS-740 GCE doesn't always return id, selfLink on lists. 

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/ListPage.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/ListPage.java
@@ -30,6 +30,7 @@ import org.jclouds.googlecloudstorage.domain.Resource.Kind;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -47,7 +48,7 @@ public class ListPage<T> extends IterableWithMarker<T> {
 
       this.kind = checkNotNull(kind, "kind");
       this.nextPageToken = nextPageToken;
-      this.items = items != null ? ImmutableSet.copyOf(items) : ImmutableSet.<T> of();
+      this.items = items != null ? ImmutableList.copyOf(items) : ImmutableList.<T> of();
       this.prefixes = prefixes != null ? prefixes : ImmutableSet.<String> of();
     }
 
@@ -110,7 +111,7 @@ public class ListPage<T> extends IterableWithMarker<T> {
 
       private Kind kind;
       private String nextPageToken;
-      private ImmutableSet.Builder<T> items = ImmutableSet.builder();
+      private ImmutableList.Builder<T> items = ImmutableList.builder();
       private ImmutableSet.Builder<String> prefixes = ImmutableSet.builder();
 
       public Builder<T> kind(Kind kind) {

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/parse/DefaultObjectAclListTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/parse/DefaultObjectAclListTest.java
@@ -27,8 +27,6 @@ import org.jclouds.googlecloudstorage.domain.internal.ProjectTeam;
 import org.jclouds.googlecloudstorage.domain.internal.ProjectTeam.Team;
 import org.jclouds.googlecloudstorage.internal.BaseGoogleCloudStorageParseTest;
 
-import com.google.common.collect.ImmutableSet;
-
 public class DefaultObjectAclListTest extends BaseGoogleCloudStorageParseTest<ListDefaultObjectAccessControls> {
 
    private DefaultObjectAccessControls item_1 = DefaultObjectAccessControls.builder()
@@ -44,7 +42,6 @@ public class DefaultObjectAclListTest extends BaseGoogleCloudStorageParseTest<Li
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
    public ListDefaultObjectAccessControls expected() {
-      return ListDefaultObjectAccessControls.builder().kind(Kind.OBJECT_ACCESS_CONTROLS).items(ImmutableSet.of(item_1))
-               .build();
+      return ListDefaultObjectAccessControls.builder().kind(Kind.OBJECT_ACCESS_CONTROLS).addItems(item_1).build();
    }
 }

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/parse/ObjectAclListTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/parse/ObjectAclListTest.java
@@ -27,8 +27,6 @@ import org.jclouds.googlecloudstorage.domain.ObjectAccessControls;
 import org.jclouds.googlecloudstorage.domain.Resource.Kind;
 import org.jclouds.googlecloudstorage.internal.BaseGoogleCloudStorageParseTest;
 
-import com.google.common.collect.ImmutableSet;
-
 public class ObjectAclListTest extends BaseGoogleCloudStorageParseTest<ListObjectAccessControls> {
 
    private ObjectAccessControls item1 = ObjectAccessControls
@@ -49,7 +47,7 @@ public class ObjectAclListTest extends BaseGoogleCloudStorageParseTest<ListObjec
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
    public ListObjectAccessControls expected() {
-      return ListObjectAccessControls.builder().kind(Kind.OBJECT_ACCESS_CONTROLS).items(ImmutableSet.of(item1)).build();
+      return ListObjectAccessControls.builder().kind(Kind.OBJECT_ACCESS_CONTROLS).addItems(item1).build();
    }
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/ListPage.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/ListPage.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.googlecomputeengine.domain.Resource.Kind;
 
 import java.beans.ConstructorProperties;
-import java.net.URI;
 import java.util.Iterator;
 
 import org.jclouds.collect.IterableWithMarker;
@@ -30,7 +29,7 @@ import org.jclouds.collect.IterableWithMarker;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 
 /**
  * The collection returned from any <code>listFirstPage()</code> method.
@@ -38,32 +37,18 @@ import com.google.common.collect.ImmutableSet;
 public class ListPage<T> extends IterableWithMarker<T> {
 
    private final Kind kind;
-   private final String id;
-   private final URI selfLink;
    private final String nextPageToken;
    private final Iterable<T> items;
 
-   @ConstructorProperties({
-           "kind", "id", "selfLink", "nextPageToken", "items"
-   })
-   protected ListPage(Kind kind, String id, URI selfLink, String nextPageToken, Iterable<T> items) {
-      this.id = checkNotNull(id, "id");
-      this.kind = checkNotNull(kind, "kind of %id", id);
-      this.selfLink = checkNotNull(selfLink, "selfLink of %id", id);
+   @ConstructorProperties({ "kind", "nextPageToken", "items" })
+   protected ListPage(Kind kind, String nextPageToken, Iterable<T> items) {
+      this.kind = checkNotNull(kind, "kind");
       this.nextPageToken = nextPageToken;
-      this.items = items != null ? ImmutableSet.copyOf(items) : ImmutableSet.<T>of();
+      this.items = items != null ? ImmutableList.copyOf(items) : ImmutableList.<T>of();
    }
 
    public Kind getKind() {
       return kind;
-   }
-
-   public String getId() {
-      return id;
-   }
-
-   public URI getSelfLink() {
-      return selfLink;
    }
 
    @Override
@@ -76,39 +61,26 @@ public class ListPage<T> extends IterableWithMarker<T> {
       return checkNotNull(items, "items").iterator();
    }
 
-   /**
-    * {@inheritDoc}
-    */
    @Override
    public int hashCode() {
-      return Objects.hashCode(kind, id);
+      return Objects.hashCode(kind, items);
    }
 
-   /**
-    * {@inheritDoc}
-    */
    @Override
    public boolean equals(Object obj) {
-      if (this == obj) return true;
-      if (obj == null || getClass() != obj.getClass()) return false;
+      if (this == obj)
+         return true;
+      if (obj == null || getClass() != obj.getClass())
+         return false;
       ListPage<?> that = ListPage.class.cast(obj);
-      return equal(this.kind, that.kind)
-              && equal(this.id, that.id);
+      return equal(this.kind, that.kind) && equal(this.items, that.items);
    }
 
    protected MoreObjects.ToStringHelper string() {
-      return toStringHelper(this)
-              .omitNullValues()
-              .add("kind", kind)
-              .add("id", id)
-              .add("selfLink", selfLink)
-              .add("nextPageToken", nextPageToken)
-              .add("items", items);
+      return toStringHelper(this).omitNullValues().add("kind", kind).add("nextPageToken", nextPageToken)
+            .add("items", items);
    }
 
-   /**
-    * {@inheritDoc}
-    */
    @Override
    public String toString() {
       return string().toString();
@@ -125,23 +97,11 @@ public class ListPage<T> extends IterableWithMarker<T> {
    public static final class Builder<T> {
 
       private Kind kind;
-      private String id;
-      private URI selfLink;
       private String nextPageToken;
-      private ImmutableSet.Builder<T> items = ImmutableSet.builder();
+      private ImmutableList.Builder<T> items = ImmutableList.builder();
 
       public Builder<T> kind(Kind kind) {
          this.kind = kind;
-         return this;
-      }
-
-      public Builder<T> id(String id) {
-         this.id = id;
-         return this;
-      }
-
-      public Builder<T> selfLink(URI selfLink) {
-         this.selfLink = selfLink;
          return this;
       }
 
@@ -161,14 +121,12 @@ public class ListPage<T> extends IterableWithMarker<T> {
       }
 
       public ListPage<T> build() {
-         return new ListPage<T>(kind, id, selfLink, nextPageToken, items.build());
+         return new ListPage<T>(kind, nextPageToken, items.build());
       }
 
       public Builder<T> fromPagedList(ListPage<T> in) {
          return this
                  .kind(in.getKind())
-                 .id(in.getId())
-                 .selfLink(in.getSelfLink())
                  .nextPageToken((String) in.nextMarker().orNull())
                  .items(in);
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionOperationApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionOperationApiExpectTest.java
@@ -77,8 +77,6 @@ public class RegionOperationApiExpectTest extends BaseGoogleComputeEngineApiExpe
    private ListPage<Operation> expectedList() {
       return ListPage.<Operation>builder()
               .kind(Resource.Kind.OPERATION_LIST)
-              .id("projects/myproject/regions/us-central1/operations")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/regions/us-central1/operations"))
               .addItem(expected())
               .build();
    }
@@ -190,6 +188,4 @@ public class RegionOperationApiExpectTest extends BaseGoogleComputeEngineApiExpe
 
       assertTrue(regionOperationApi.listInRegion("us-central1").concat().isEmpty());
    }
-
-
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneOperationApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneOperationApiExpectTest.java
@@ -74,8 +74,6 @@ public class ZoneOperationApiExpectTest extends BaseGoogleComputeEngineApiExpect
    private ListPage<Operation> expectedList() {
       return ListPage.<Operation>builder()
               .kind(Resource.Kind.OPERATION_LIST)
-              .id("projects/myproject/zones/us-central1-a/operations")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/operations"))
               .addItem(expected())
               .build();
    }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseAddressListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseAddressListTest.java
@@ -28,8 +28,6 @@ import org.jclouds.googlecomputeengine.domain.Resource.Kind;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 @Test(groups = "unit")
 public class ParseAddressListTest extends BaseGoogleComputeEngineParseTest<ListPage<Address>> {
 
@@ -43,10 +41,8 @@ public class ParseAddressListTest extends BaseGoogleComputeEngineParseTest<ListP
    public ListPage<Address> expected() {
       return ListPage.<Address>builder()
               .kind(Kind.ADDRESS_LIST)
-              .id("projects/myproject/regions/us-central1/addresses")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/regions/us-central1/addresses"))
-              .items(ImmutableSet.of(new ParseAddressTest().expected(),
-                      Address.builder()
+              .addItem(new ParseAddressTest().expected())
+              .addItem(Address.builder()
                               .id("4881363978908129158")
                               .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse("2013-07-26T14:08:21.552-07:00"))
                               .status("RESERVED")
@@ -56,6 +52,6 @@ public class ParseAddressListTest extends BaseGoogleComputeEngineParseTest<ListP
                               .address("173.255.118.115")
                               .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/regions/us-central1/addresses/test-ip2"))
                               .build())
-              ).build();
+              .build();
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskListTest.java
@@ -28,8 +28,6 @@ import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 @Test(groups = "unit")
 public class ParseDiskListTest extends BaseGoogleComputeEngineParseTest<ListPage<Disk>> {
 
@@ -43,9 +41,7 @@ public class ParseDiskListTest extends BaseGoogleComputeEngineParseTest<ListPage
    public ListPage<Disk> expected() {
       return ListPage.<Disk>builder()
               .kind(Resource.Kind.DISK_LIST)
-              .id("projects/myproject/zones/us-central1-a/disks")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/disks"))
-              .items(ImmutableSet.of(Disk.builder()
+              .addItem(Disk.builder()
                       .id("13050421646334304115")
                       .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse("2012-11-25T01:38:48.306"))
                       .selfLink(URI.create("https://www.googleapis" +
@@ -56,6 +52,6 @@ public class ParseDiskListTest extends BaseGoogleComputeEngineParseTest<ListPage
                               ".com/compute/v1/projects/myproject/zones/us-central1-a"))
                       .status("READY")
                       .build())
-              ).build();
+              .build();
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseFirewallListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseFirewallListTest.java
@@ -29,8 +29,6 @@ import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest
 import org.jclouds.net.domain.IpProtocol;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 @Test(groups = "unit")
 public class ParseFirewallListTest extends BaseGoogleComputeEngineParseTest<ListPage<Firewall>> {
 
@@ -44,11 +42,8 @@ public class ParseFirewallListTest extends BaseGoogleComputeEngineParseTest<List
    public ListPage<Firewall> expected() {
       return ListPage.<Firewall>builder()
               .kind(Resource.Kind.FIREWALL_LIST)
-              .id("projects/google/firewalls")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/google/global/firewalls"))
-              .items(ImmutableSet.of(
-                      new ParseFirewallTest().expected()
-                      , Firewall.builder()
+              .addItem(new ParseFirewallTest().expected())
+              .addItem(Firewall.builder()
                       .id("12862241067393040785")
                       .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse("2012-04-13T03:05:04.365"))
                       .selfLink(URI.create("https://www.googleapis" +
@@ -61,8 +56,7 @@ public class ParseFirewallListTest extends BaseGoogleComputeEngineParseTest<List
                       .addAllowed(Firewall.Rule.builder()
                               .IpProtocol(IpProtocol.TCP)
                               .addPort(22).build())
-                      .build()
-              ))
+                      .build())
               .build();
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseImageListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseImageListTest.java
@@ -29,8 +29,6 @@ import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 @Test(groups = "unit")
 public class ParseImageListTest extends BaseGoogleComputeEngineParseTest<ListPage<Image>> {
 
@@ -44,9 +42,7 @@ public class ParseImageListTest extends BaseGoogleComputeEngineParseTest<ListPag
    public ListPage<Image> expected() {
       return ListPage.<Image>builder()
               .kind(Resource.Kind.IMAGE_LIST)
-              .id("projects/centos-cloud/global/images")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images"))
-              .items(ImmutableSet.of(Image.builder()
+              .addItem(Image.builder()
                       .id("12941197498378735318")
                       .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse("2012-07-16T22:16:13.468"))
                       .selfLink(URI.create("https://www.googleapis" +
@@ -63,9 +59,7 @@ public class ParseImageListTest extends BaseGoogleComputeEngineParseTest<ListPag
                                       .source("")
                                       .containerType("TAR")
                                       .build()
-                      ).build()
-
-              ))
+                      ).build())
               .build();
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceListTest.java
@@ -16,8 +16,6 @@
  */
 package org.jclouds.googlecomputeengine.parse;
 
-import java.net.URI;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
@@ -25,8 +23,6 @@ import org.jclouds.googlecomputeengine.domain.Instance;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
-
-import com.google.common.collect.ImmutableSet;
 
 public class ParseInstanceListTest extends BaseGoogleComputeEngineParseTest<ListPage<Instance>> {
 
@@ -40,9 +36,7 @@ public class ParseInstanceListTest extends BaseGoogleComputeEngineParseTest<List
    public ListPage<Instance> expected() {
       return ListPage.<Instance>builder()
               .kind(Resource.Kind.INSTANCE_LIST)
-              .id("projects/myproject/zones/us-central1-a/instances")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/instances"))
-              .items(ImmutableSet.of(new ParseInstanceTest().expected()))
+              .addItem(new ParseInstanceTest().expected())
               .build();
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseMachineTypeListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseMachineTypeListTest.java
@@ -30,7 +30,6 @@ import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest
 
 public class ParseMachineTypeListTest extends BaseGoogleComputeEngineParseTest<ListPage<MachineType>> {
 
-
    @Override
    public String resource() {
       return "/machinetype_list.json";
@@ -42,8 +41,6 @@ public class ParseMachineTypeListTest extends BaseGoogleComputeEngineParseTest<L
       SimpleDateFormatDateService dateService = new SimpleDateFormatDateService();
       return ListPage.<MachineType>builder()
               .kind(MACHINE_TYPE_LIST)
-              .id("projects/myproject/machineTypes")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/machineTypes"))
               .addItem(MachineType.builder()
                       .id("4618642685664990776")
                       .creationTimestamp(dateService.iso8601DateParse("2013-04-25T13:32:49.088-07:00"))

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseNetworkListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseNetworkListTest.java
@@ -16,8 +16,6 @@
  */
 package org.jclouds.googlecomputeengine.parse;
 
-import java.net.URI;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
@@ -25,8 +23,6 @@ import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Network;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
-
-import com.google.common.collect.ImmutableSet;
 
 public class ParseNetworkListTest extends BaseGoogleComputeEngineParseTest<ListPage<Network>> {
 
@@ -40,10 +36,7 @@ public class ParseNetworkListTest extends BaseGoogleComputeEngineParseTest<ListP
    public ListPage<Network> expected() {
       return ListPage.<Network>builder()
               .kind(Resource.Kind.NETWORK_LIST)
-              .id("projects/myproject/networks")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/networks"))
-              .items(ImmutableSet.of(new ParseNetworkTest().expected()))
+              .addItem(new ParseNetworkTest().expected())
               .build();
-
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseOperationListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseOperationListTest.java
@@ -16,8 +16,6 @@
  */
 package org.jclouds.googlecomputeengine.parse;
 
-import java.net.URI;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
@@ -38,8 +36,6 @@ public class ParseOperationListTest extends BaseGoogleComputeEngineParseTest<Lis
    public ListPage<Operation> expected() {
       return ListPage.<Operation>builder()
               .kind(Resource.Kind.OPERATION_LIST)
-              .id("projects/myproject/global/operations")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/global/operations"))
               .addItem(new ParseOperationTest().expected())
               .build();
    }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRegionListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRegionListTest.java
@@ -28,8 +28,6 @@ import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 @Test(groups = "unit")
 public class ParseRegionListTest extends BaseGoogleComputeEngineParseTest<ListPage<Region>> {
 
@@ -42,31 +40,28 @@ public class ParseRegionListTest extends BaseGoogleComputeEngineParseTest<ListPa
    @Consumes(MediaType.APPLICATION_JSON)
    public ListPage<Region> expected() {
       return ListPage.<Region>builder()
-              .kind(Resource.Kind.REGION_LIST)
-              .id("projects/myproject/regions")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/regions"))
-              .items(ImmutableSet.of(
-                      new ParseRegionTest().expected(),
-                      Region.builder()
-                              .id("6396763663251190992")
-                              .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse
-                                      ("2013-07-08T14:40:37.939-07:00"))
-                              .selfLink(URI.create("https://www.googleapis" +
-                                      ".com/compute/v1/projects/myproject/regions/us-central2"))
-                              .name("us-central2")
-                              .description("us-central2")
-                              .status(Region.Status.UP)
-                              .zone(URI.create("https://www.googleapis.com/compute/v1/zones/us-central2-a"))
-                              .addQuota("INSTANCES", 0, 8)
-                              .addQuota("CPUS", 0, 8)
-                              .addQuota("EPHEMERAL_ADDRESSES", 0, 8)
-                              .addQuota("DISKS", 0, 8)
-                              .addQuota("DISKS_TOTAL_GB", 0, 100)
-                              .addQuota("SNAPSHOTS", 0, 1000)
-                              .addQuota("NETWORKS", 1, 5)
-                              .addQuota("FIREWALLS", 2, 100)
-                              .addQuota("IMAGES", 0, 100)
-                              .build()))
-              .build();
+                     .kind(Resource.Kind.REGION_LIST)
+                     .addItem(new ParseRegionTest().expected())
+                     .addItem(Region.builder()
+                                    .id("6396763663251190992")
+                                    .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse
+                                            ("2013-07-08T14:40:37.939-07:00"))
+                                    .selfLink(URI.create("https://www.googleapis" +
+                                            ".com/compute/v1/projects/myproject/regions/us-central2"))
+                                    .name("us-central2")
+                                    .description("us-central2")
+                                    .status(Region.Status.UP)
+                                    .zone(URI.create("https://www.googleapis.com/compute/v1/zones/us-central2-a"))
+                                    .addQuota("INSTANCES", 0, 8)
+                                    .addQuota("CPUS", 0, 8)
+                                    .addQuota("EPHEMERAL_ADDRESSES", 0, 8)
+                                    .addQuota("DISKS", 0, 8)
+                                    .addQuota("DISKS_TOTAL_GB", 0, 100)
+                                    .addQuota("SNAPSHOTS", 0, 1000)
+                                    .addQuota("NETWORKS", 1, 5)
+                                    .addQuota("FIREWALLS", 2, 100)
+                                    .addQuota("IMAGES", 0, 100)
+                                    .build())
+                     .build();
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRouteListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRouteListTest.java
@@ -28,7 +28,7 @@ import org.jclouds.googlecomputeengine.domain.Route;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 
 @Test(groups = "unit")
 public class ParseRouteListTest extends BaseGoogleComputeEngineParseTest<ListPage<Route>> {
@@ -43,9 +43,7 @@ public class ParseRouteListTest extends BaseGoogleComputeEngineParseTest<ListPag
    public ListPage<Route> expected() {
       return ListPage.<Route>builder()
               .kind(Kind.ROUTE_LIST)
-              .id("projects/myproject/global/routes")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/global/routes"))
-              .items(ImmutableSet.of(new ParseRouteTest().expected(),
+              .items(ImmutableList.of(new ParseRouteTest().expected(),
                       Route.builder()
                               .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/global/routes/default-route-fc92a41ecb5a8d17"))
                               .id("507025480040058551")

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseSnapshotListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseSnapshotListTest.java
@@ -28,8 +28,6 @@ import org.jclouds.googlecomputeengine.domain.Snapshot;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 @Test(groups = "unit")
 public class ParseSnapshotListTest extends BaseGoogleComputeEngineParseTest<ListPage<Snapshot>> {
 
@@ -43,22 +41,21 @@ public class ParseSnapshotListTest extends BaseGoogleComputeEngineParseTest<List
    public ListPage<Snapshot> expected() {
       return ListPage.<Snapshot>builder()
               .kind(Kind.SNAPSHOT_LIST)
-              .id("projects/myproject/global/snapshots")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/global/snapshots"))
-              .items(ImmutableSet.of(
-                      new ParseSnapshotTest().expected(), Snapshot.builder()
-                      .selfLink(URI.create("https://www.googleapis" +
-                              ".com/compute/v1/projects/myproject/global/snapshots/test-snap2"))
-                      .id("13895715048576107883")
-                      .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse
-                              ("2013-07-26T12:57:01.927-07:00"))
-                      .status("READY")
-                      .sizeGb(10)
-                      .sourceDisk(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/disks/testimage1"))
-                      .name("test-snap2")
-                      .description("")
-                      .sourceDiskId("8243603669926824540")
-                      .build()))
+              .addItem(new ParseSnapshotTest().expected())
+              .addItem(Snapshot.builder()
+                               .selfLink(URI.create("https://www.googleapis" +
+                                     ".com/compute/v1/projects/myproject/global/snapshots/test-snap2"))
+                               .id("13895715048576107883")
+                               .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse
+                                     ("2013-07-26T12:57:01.927-07:00"))
+                               .status("READY")
+                               .sizeGb(10)
+                               .sourceDisk(URI.create("https://www.googleapis.com/compute/v1/projects/myproject" +
+                                     "/zones/us-central1-a/disks/testimage1"))
+                               .name("test-snap2")
+                               .description("")
+                               .sourceDiskId("8243603669926824540")
+                               .build())
               .build();
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseZoneListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseZoneListTest.java
@@ -28,8 +28,6 @@ import org.jclouds.googlecomputeengine.domain.Zone;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 @Test(groups = "unit")
 public class ParseZoneListTest extends BaseGoogleComputeEngineParseTest<ListPage<Zone>> {
 
@@ -42,29 +40,26 @@ public class ParseZoneListTest extends BaseGoogleComputeEngineParseTest<ListPage
    @Consumes(MediaType.APPLICATION_JSON)
    public ListPage<Zone> expected() {
       return ListPage.<Zone>builder()
-              .kind(Resource.Kind.ZONE_LIST)
-              .id("projects/myproject/zones")
-              .selfLink(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/zones"))
-              .items(ImmutableSet.of(
-                      new ParseZoneTest().expected()
-                      , Zone.builder()
-                      .id("13024414164050619686")
-                      .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse
-                              ("2012-10-24T20:13:19.271"))
-                      .selfLink(URI.create("https://www.googleapis" +
-                              ".com/compute/v1/projects/myproject/zones/us-central1-b"))
-                      .name("us-central1-b")
-                      .description("us-central1-b")
-                      .status(Zone.Status.UP)
-                      .addMaintenanceWindow(Zone.MaintenanceWindow.builder()
-                              .name("2013-02-17-planned-outage")
-                              .description("maintenance zone")
-                              .beginTime(new SimpleDateFormatDateService().iso8601DateParse
-                                      ("2013-02-17T08:00:00.000"))
-                              .endTime(new SimpleDateFormatDateService().iso8601DateParse
-                                      ("2013-03-03T08:00:00.000"))
-                              .build())
-                      .build()))
-              .build();
+                     .kind(Resource.Kind.ZONE_LIST)
+                     .addItem(new ParseZoneTest().expected())
+                     .addItem(Zone.builder()
+                                  .id("13024414164050619686")
+                                  .creationTimestamp(new SimpleDateFormatDateService().iso8601DateParse
+                                    ("2012-10-24T20:13:19.271"))
+                                  .selfLink(URI.create("https://www.googleapis" +
+                                    ".com/compute/v1/projects/myproject/zones/us-central1-b"))
+                                  .name("us-central1-b")
+                                  .description("us-central1-b")
+                                  .status(Zone.Status.UP)
+                                  .addMaintenanceWindow(Zone.MaintenanceWindow.builder()
+                                          .name("2013-02-17-planned-outage")
+                                          .description("maintenance zone")
+                                          .beginTime(new SimpleDateFormatDateService().iso8601DateParse
+                                                  ("2013-02-17T08:00:00.000"))
+                                          .endTime(new SimpleDateFormatDateService().iso8601DateParse
+                                                  ("2013-03-03T08:00:00.000"))
+                                          .build())
+                                  .build())
+                    .build();
    }
 }


### PR DESCRIPTION
The extra fields on ListPage were causing NPEs as they were expected present. There's no value in id, selfLink on a list anyway.

While working on this, I noticed we were backing an Iterable with a Set. It is cheaper to do this with a List, so I switched it.
