### PR TITLE
Revert "Add snapshot repository so modernizer doesn't fail."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,20 +53,6 @@
     </repository>
   </repositories>
 
-  <!-- For modernizer, which depends on jclouds-resources snapshot. -->
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache-snapshots</id>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <modules>
     <module>oauth</module>
     <module>google-compute-engine</module>


### PR DESCRIPTION
This reverts commit c80849a711126bbd3493177812e2328ab7ac2a83. The
snapshot repository has now been added to the jclouds-project POM.

See https://github.com/jclouds/jclouds/commit/79d4b48d0151667db062a7035b23b28d7a1e1daf
