### PR TITLE
Introduce BucketAccessControlTemplate

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/binders/BucketAccessControlsBinder.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/binders/BucketAccessControlsBinder.java
@@ -19,7 +19,8 @@ package org.jclouds.googlecloudstorage.binders;
 import java.util.Map;
 
 import javax.inject.Inject;
-import org.jclouds.googlecloudstorage.domain.BucketAccessControls;
+
+import org.jclouds.googlecloudstorage.domain.templates.BucketAccessControlsTemplate;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.rest.MapBinder;
 import org.jclouds.rest.binders.BindToJsonPayload;
@@ -31,7 +32,7 @@ public class BucketAccessControlsBinder implements MapBinder {
 
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Map<String, Object> postParams) {
-      BucketAccessControls postBucket = (BucketAccessControls) postParams.get("BACLInsert");
+      BucketAccessControlsTemplate postBucket = (BucketAccessControlsTemplate) postParams.get("template");
       return bindToRequest(request, postBucket);
    }
 

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/BucketAccessControlsTemplate.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/BucketAccessControlsTemplate.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecloudstorage.domain.templates;
+
+import org.jclouds.googlecloudstorage.domain.DomainResourceReferences.Role;
+
+/**
+ * Represents a Object Access Control Resource.
+ *
+ * @see <a href= "https://developers.google.com/storage/docs/json_api/v1/objectAccessControls"/>
+ */
+public class BucketAccessControlsTemplate {
+
+   protected String entity;
+   protected Role role;
+
+   public BucketAccessControlsTemplate role(Role role) {
+      this.role = role;
+      return this;
+   }
+
+   public BucketAccessControlsTemplate entity(String entity) {
+      this.entity = entity;
+      return this;
+   }
+
+   public String getEntity() {
+      return entity;
+   }
+
+   public Role getRole() {
+      return role;
+   }
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static BucketAccessControlsTemplate fromObjectAccessControlsTemplate(
+            BucketAccessControlsTemplate objectAccessControlsTemplate) {
+      return Builder.fromObjectAccessControlsTemplate(objectAccessControlsTemplate);
+   }
+
+   public static class Builder {
+
+      public static BucketAccessControlsTemplate fromObjectAccessControlsTemplate(BucketAccessControlsTemplate in) {
+         return new BucketAccessControlsTemplate().role(in.getRole()).entity(in.getEntity());
+      }
+
+   }
+}

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/BucketAccessControlsApi.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/BucketAccessControlsApi.java
@@ -33,6 +33,7 @@ import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.googlecloudstorage.binders.BucketAccessControlsBinder;
 import org.jclouds.googlecloudstorage.domain.BucketAccessControls;
 import org.jclouds.googlecloudstorage.domain.ListBucketAccessControls;
+import org.jclouds.googlecloudstorage.domain.templates.BucketAccessControlsTemplate;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
@@ -84,8 +85,8 @@ public interface BucketAccessControlsApi {
     * @param bucketName
     *           Name of the bucket of which ACL to be created
     *
-    * @param bucketAccessControls
-    *           In the request body,supply a BucketAccessControls resource with role and entity
+    * @param template
+    *           In the request body,supply a {@link BucketAccessControlsTemplate} resource with role and entity
     *
     * @return If successful, this method returns a BucketAccessControls resource in the response body
     */
@@ -97,7 +98,7 @@ public interface BucketAccessControlsApi {
    @OAuthScopes(STORAGE_FULLCONTROL_SCOPE)
    @MapBinder(BucketAccessControlsBinder.class)
    BucketAccessControls createBucketAccessControls(@PathParam("bucket") String bucketName,
-            @PayloadParam("BACLInsert") BucketAccessControls bucketAccessControls);
+            @PayloadParam("template") BucketAccessControlsTemplate template);
 
    /**
     * Permanently deletes the ACL entry for the specified entity on the specified bucket.
@@ -143,9 +144,9 @@ public interface BucketAccessControlsApi {
     * @param entity
     *           The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     *           group-emailAddress, allUsers, or allAuthenticatedUsers. In the request body, supply a
-    *           BucketAccessControls resource with role
+    *           {@link BucketAccessControlsTemplate} resource with role
     *
-    * @return If successful, this method returns a BucketAccessControls resource in the response body
+    * @return If successful, this method returns a {@link BucketAccessControlsTemplate} resource in the response body
     */
 
    @Named("BucketAccessControls:update")
@@ -157,7 +158,7 @@ public interface BucketAccessControlsApi {
    @Fallback(NullOnNotFoundOr404.class)
    BucketAccessControls updateBucketAccessControls(@PathParam("bucket") String bucketName,
             @PathParam("entity") String entity,
-            @BinderParam(BindToJsonPayload.class) BucketAccessControls bucketAccessControls);
+            @BinderParam(BindToJsonPayload.class) BucketAccessControlsTemplate template);
 
    /**
     * Updates an ACL entry on the specified bucket.
@@ -168,8 +169,8 @@ public interface BucketAccessControlsApi {
     *           The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     *           group-emailAddress, allUsers, or allAuthenticatedUsers
     *
-    * @param bucketAccessControls
-    *           In the request body, supply a BucketAccessControls resource with role
+    * @param template
+    *           In the request body, supply a {@link BucketAccessControlsTemplate} resource with role
     *
     * @return If successful, this method returns a BucketAccessControls resource in the response body
     */
@@ -183,5 +184,5 @@ public interface BucketAccessControlsApi {
    @Fallback(NullOnNotFoundOr404.class)
    BucketAccessControls patchBucketAccessControls(@PathParam("bucket") String bucketName,
             @PathParam("entity") String entity,
-            @BinderParam(BindToJsonPayload.class) BucketAccessControls bucketAccessControls);
+            @BinderParam(BindToJsonPayload.class) BucketAccessControlsTemplate template);
 }

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/BucketAccessControlsApiExpectTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/BucketAccessControlsApiExpectTest.java
@@ -21,12 +21,10 @@ import static org.jclouds.googlecloudstorage.reference.GoogleCloudStorageConstan
 import static org.testng.Assert.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
-import java.net.URI;
-
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.googlecloudstorage.domain.BucketAccessControls;
 import org.jclouds.googlecloudstorage.domain.DomainResourceReferences.Role;
+import org.jclouds.googlecloudstorage.domain.templates.BucketAccessControlsTemplate;
 import org.jclouds.googlecloudstorage.internal.BaseGoogleCloudStorageApiExpectTest;
 import org.jclouds.googlecloudstorage.parse.BucketAclGetTest;
 import org.jclouds.googlecloudstorage.parse.BucketAclInsertTest;
@@ -48,7 +46,7 @@ public class BucketAccessControlsApiExpectTest extends BaseGoogleCloudStorageApi
    private final HttpResponse GET_BUCKETACL_RESPONSE = HttpResponse.builder().statusCode(200)
             .payload(staticPayloadFromResource("/bucket_acl_get.json")).build();
 
-   private  final HttpResponse CREATE_BUCKETACL_RESPONSE = HttpResponse.builder().statusCode(200)
+   private final HttpResponse CREATE_BUCKETACL_RESPONSE = HttpResponse.builder().statusCode(200)
             .payload(staticPayloadFromResource("/bucket_acl_insert_response.json")).build();
 
    private final HttpRequest LIST_BUCKETACL_REQUEST = HttpRequest.builder().method("GET")
@@ -105,20 +103,16 @@ public class BucketAccessControlsApiExpectTest extends BaseGoogleCloudStorageApi
                .endpoint("https://www.googleapis.com/storage/v1/b/jcloudtestbucket/acl")
                .addHeader("Accept", "application/json")
                .addHeader("Authorization", "Bearer " + TOKEN)
-               .payload(payloadFromResourceWithContentType("/bucket_acl_insert_response.json",
+               .payload(payloadFromResourceWithContentType("/bucket_acl_insert_initial.json",
                         MediaType.APPLICATION_JSON)).build();
 
       BucketAccessControlsApi api = requestsSendResponses(requestForScopes(STORAGE_FULLCONTROL_SCOPE), TOKEN_RESPONSE,
                insertRequest, CREATE_BUCKETACL_RESPONSE).getBucketAccessControlsApi();
 
-      BucketAccessControls options = BucketAccessControls
-               .builder()
-               .id("jcloudtestbucket/allAuthenticatedUsers")
-               .selfLink(
-                        URI.create("https://content.googleapis.com/storage/v1/b/jcloudtestbucket/acl/allAuthenticatedUsers"))
-               .bucket(EXPECTED_TEST_BUCKET).entity("allAuthenticatedUsers").role(Role.WRITER).etag("CAQ=").build();
+      BucketAccessControlsTemplate template = new BucketAccessControlsTemplate().entity("allAuthenticatedUsers").role(
+               Role.WRITER);
 
-      assertEquals(api.createBucketAccessControls(EXPECTED_TEST_BUCKET, options), new BucketAclInsertTest().expected());
+      assertEquals(api.createBucketAccessControls(EXPECTED_TEST_BUCKET, template), new BucketAclInsertTest().expected());
 
    }
 
@@ -157,20 +151,18 @@ public class BucketAccessControlsApiExpectTest extends BaseGoogleCloudStorageApi
                .endpoint("https://www.googleapis.com/storage/v1/b/jcloudtestbucket/acl/allUsers")
                .addHeader("Accept", "application/json")
                .addHeader("Authorization", "Bearer " + TOKEN)
-               .payload(payloadFromResourceWithContentType("/bucket_acl_update_response.json",
+               .payload(payloadFromResourceWithContentType("/bucket_acl_update_initial.json",
                         MediaType.APPLICATION_JSON)).build();
 
       HttpResponse updateResponse = HttpResponse.builder().statusCode(200)
-               .payload(staticPayloadFromResource("/bucket_acl_update_initial.json")).build();
+               .payload(staticPayloadFromResource("/bucket_acl_update_response.json")).build();
 
       BucketAccessControlsApi api = requestsSendResponses(requestForScopes(STORAGE_FULLCONTROL_SCOPE), TOKEN_RESPONSE,
                update, updateResponse).getBucketAccessControlsApi();
 
-      BucketAccessControls options = BucketAccessControls.builder().id("jcloudtestbucket/allUsers")
-               .selfLink(URI.create("https://content.googleapis.com/storage/v1/b/jcloudtestbucket/acl/allUsers"))
-               .bucket(EXPECTED_TEST_BUCKET).entity("allUsers").role(Role.OWNER).etag("CAg=").build();
+      BucketAccessControlsTemplate template = new BucketAccessControlsTemplate().entity("allUsers").role(Role.OWNER);
 
-      assertEquals(api.updateBucketAccessControls(EXPECTED_TEST_BUCKET, "allUsers", options),
+      assertEquals(api.updateBucketAccessControls(EXPECTED_TEST_BUCKET, "allUsers", template),
                new BucketAclUpdateTest().expected());
    }
 
@@ -182,20 +174,18 @@ public class BucketAccessControlsApiExpectTest extends BaseGoogleCloudStorageApi
                .endpoint("https://www.googleapis.com/storage/v1/b/jcloudtestbucket/acl/allUsers")
                .addHeader("Accept", "application/json")
                .addHeader("Authorization", "Bearer " + TOKEN)
-               .payload(payloadFromResourceWithContentType("/bucket_acl_update_response.json",
+               .payload(payloadFromResourceWithContentType("/bucket_acl_update_initial.json",
                         MediaType.APPLICATION_JSON)).build();
 
       HttpResponse patchResponse = HttpResponse.builder().statusCode(200)
-               .payload(staticPayloadFromResource("/bucket_acl_update_initial.json")).build();
+               .payload(staticPayloadFromResource("/bucket_acl_update_response.json")).build();
 
       BucketAccessControlsApi api = requestsSendResponses(requestForScopes(STORAGE_FULLCONTROL_SCOPE), TOKEN_RESPONSE,
                patchRequest, patchResponse).getBucketAccessControlsApi();
 
-      BucketAccessControls options = BucketAccessControls.builder().id("jcloudtestbucket/allUsers")
-               .selfLink(URI.create("https://content.googleapis.com/storage/v1/b/jcloudtestbucket/acl/allUsers"))
-               .bucket(EXPECTED_TEST_BUCKET).entity("allUsers").role(Role.OWNER).etag("CAg=").build();
+      BucketAccessControlsTemplate template = new BucketAccessControlsTemplate().entity("allUsers").role(Role.OWNER);
 
-      assertEquals(api.patchBucketAccessControls(EXPECTED_TEST_BUCKET, "allUsers", options),
+      assertEquals(api.patchBucketAccessControls(EXPECTED_TEST_BUCKET, "allUsers", template),
                new BucketAclUpdateTest().expected());
    }
 }

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/BucketAccessControlsApiLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/BucketAccessControlsApiLiveTest.java
@@ -26,6 +26,7 @@ import org.jclouds.googlecloudstorage.domain.BucketAccessControls;
 import org.jclouds.googlecloudstorage.domain.DomainResourceReferences.Role;
 import org.jclouds.googlecloudstorage.domain.ListBucketAccessControls;
 import org.jclouds.googlecloudstorage.domain.Resource.Kind;
+import org.jclouds.googlecloudstorage.domain.templates.BucketAccessControlsTemplate;
 import org.jclouds.googlecloudstorage.domain.templates.BucketTemplate;
 import org.jclouds.googlecloudstorage.internal.BaseGoogleCloudStorageApiLiveTest;
 import org.testng.annotations.Test;
@@ -47,8 +48,7 @@ public class BucketAccessControlsApiLiveTest extends BaseGoogleCloudStorageApiLi
    @Test(groups = "live")
    public void testCreateBucketAcl() {
       createBucket(BUCKET_NAME);
-      BucketAccessControls bucketAcl = BucketAccessControls.builder().bucket(BUCKET_NAME).entity("allUsers")
-               .role(Role.READER).build();
+      BucketAccessControlsTemplate bucketAcl = new BucketAccessControlsTemplate().entity("allUsers").role(Role.READER);
       BucketAccessControls response = api().createBucketAccessControls(BUCKET_NAME, bucketAcl);
 
       assertNotNull(response);
@@ -57,9 +57,8 @@ public class BucketAccessControlsApiLiveTest extends BaseGoogleCloudStorageApiLi
 
    @Test(groups = "live", dependsOnMethods = "testCreateBucketAcl")
    public void testUpdateBucketAcl() {
-      BucketAccessControls bucketAcl = BucketAccessControls.builder().bucket(BUCKET_NAME).entity("allUsers")
-               .role(Role.WRITER).build();
-      BucketAccessControls response = api().updateBucketAccessControls(BUCKET_NAME, "allUsers", bucketAcl);
+      BucketAccessControlsTemplate template = new BucketAccessControlsTemplate().entity("allUsers").role(Role.WRITER);
+      BucketAccessControls response = api().updateBucketAccessControls(BUCKET_NAME, "allUsers", template);
 
       assertNotNull(response);
       assertEquals(response.getId(), BUCKET_NAME + "/allUsers");
@@ -86,9 +85,8 @@ public class BucketAccessControlsApiLiveTest extends BaseGoogleCloudStorageApiLi
 
    @Test(groups = "live", dependsOnMethods = "testUpdateBucketAcl")
    public void testPatchBucketAcl() {
-      BucketAccessControls bucketAcl = BucketAccessControls.builder().bucket(BUCKET_NAME).entity("allUsers")
-               .role(Role.READER).build();
-      BucketAccessControls response = api().patchBucketAccessControls(BUCKET_NAME, "allUsers", bucketAcl);
+      BucketAccessControlsTemplate template = new BucketAccessControlsTemplate().entity("allUsers").role(Role.READER);
+      BucketAccessControls response = api().patchBucketAccessControls(BUCKET_NAME, "allUsers", template);
 
       assertNotNull(response);
       assertEquals(response.getId(), BUCKET_NAME + "/allUsers");

--- a/google-cloud-storage/src/test/resources/bucket_acl_insert_initial.json
+++ b/google-cloud-storage/src/test/resources/bucket_acl_insert_initial.json
@@ -1,0 +1,4 @@
+{
+   "entity": "allAuthenticatedUsers",
+   "role": "WRITER"
+}

--- a/google-cloud-storage/src/test/resources/bucket_acl_update_initial.json
+++ b/google-cloud-storage/src/test/resources/bucket_acl_update_initial.json
@@ -1,9 +1,4 @@
 {
-   "kind": "storage#bucketAccessControl",
-   "id": "jcloudtestbucket/allUsers",
-   "selfLink": "https://content.googleapis.com/storage/v1/b/jcloudtestbucket/acl/allUsers",
-   "bucket": "jcloudtestbucket",
    "entity": "allUsers",
-   "role": "READER",
-   "etag": "CAM="
+   "role": "OWNER"
 }

--- a/google-cloud-storage/src/test/resources/bucket_insert_request_payload.json
+++ b/google-cloud-storage/src/test/resources/bucket_insert_request_payload.json
@@ -1,3 +1,3 @@
 {
-   "name": "bhashbucket"
+   "name":"bhashbucket"
 }


### PR DESCRIPTION
This would make the Bucket Acceess Control API constistent with other GCS access controls.
