### PR TITLE
Add coverage of DiskType Api

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineApi.java
@@ -23,6 +23,7 @@ import javax.ws.rs.PathParam;
 
 import org.jclouds.googlecomputeengine.features.AddressApi;
 import org.jclouds.googlecomputeengine.features.DiskApi;
+import org.jclouds.googlecomputeengine.features.DiskTypeApi;
 import org.jclouds.googlecomputeengine.features.FirewallApi;
 import org.jclouds.googlecomputeengine.features.GlobalOperationApi;
 import org.jclouds.googlecomputeengine.features.ImageApi;
@@ -67,6 +68,15 @@ public interface GoogleComputeEngineApi extends Closeable {
    @Delegate
    @Path("/projects/{project}")
    DiskApi getDiskApiForProject(@PathParam("project") String projectName);
+
+   /**
+    * Provides access to DiskType features
+    *
+    *  @param projectName the name of the project
+    */
+   @Delegate
+   @Path("/projects/{project}")
+   DiskTypeApi getDiskTypeApiForProject(@PathParam("project") String projectName);
 
    /**
     * Provides access to Firewall features

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/DiskType.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/DiskType.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.domain;
+
+import static com.google.common.base.Optional.fromNullable;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.beans.ConstructorProperties;
+import java.net.URI;
+import java.util.Date;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
+
+/**
+ * Represents a DiskType resource.
+ *
+ * @see <a href="https://cloud.google.com/compute/docs/reference/latest/diskTypes"/>
+ */
+public final class DiskType extends Resource {
+
+   private final String zone;
+   private final Long defaultDiskSizeGb;
+   private final Optional<String> validDiskSize;
+   private final Optional<Deprecated> deprecated;
+
+   @ConstructorProperties({
+      "id", "creationTimestamp", "selfLink", "name", "description", "validDiskSize",
+      "deprecated", "zone", "defaultDiskSizeGb"
+   })
+   private DiskType(String id, Date creationTimestamp, URI selfLink, String name, String description,
+                  String validDiskSize, Deprecated deprecated, String zone,  long defaultDiskSizeGb){
+      super(Kind.DISK_TYPE, id == null ? "" : id, creationTimestamp, selfLink, name, description);
+      this.validDiskSize = fromNullable(validDiskSize);
+      this.deprecated = fromNullable(deprecated);
+      this.zone = checkNotNull(zone, "zone of %s", name);
+      this.defaultDiskSizeGb = defaultDiskSizeGb;
+   }
+
+   /**
+    * @return An optional textual description of the valid disk size. For example, "10GB-10TB."
+    */
+   public Optional<String> getValidDiskSize(){
+      return validDiskSize;
+   }
+
+   /**
+    * @return If applicable, the deprecation status associated with this disk type.
+    */
+   public Optional<Deprecated> getDeprecated(){
+      return deprecated;
+   }
+
+   /**
+    * @return The fully-qualified URL for the zone where the disk type resource resides.
+    */
+   public String getZone(){
+      return zone;
+   }
+
+   /**
+    * @return Server defined default disk size in GB.
+    */
+   public long getDefaultDiskSizeGb(){
+      return defaultDiskSizeGb;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   protected MoreObjects.ToStringHelper string() {
+      return super.string()
+              .add("validDiskSize", validDiskSize.orNull())
+              .add("defaultDiskSizeGb", defaultDiskSizeGb)
+              .add("zone", zone)
+              .add("deprecated", deprecated.orNull());
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String toString() {
+      return string().toString();
+   }
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public Builder toBuilder(){
+      return new Builder().fromDiskType(this);
+   }
+
+   public static final class Builder extends Resource.Builder<Builder> {
+
+      private String zone;
+      private Long defaultDiskSizeGb;
+      private String validDiskSize;
+      private Deprecated deprecated;
+
+      /**
+       * @see DiskType#getZone()
+       */
+      public Builder zone(String zone){
+         this.zone = zone;
+         return this;
+      }
+
+      /**
+       * @see DiskType#getDefaultDiskSizeGb()
+       */
+      public Builder defaultDiskSizeGb(long defaultDiskSizeGb){
+         this.defaultDiskSizeGb = defaultDiskSizeGb;
+         return this;
+      }
+
+      /**
+       * @see DiskType#getValidDiskSize()
+       */
+      public Builder validDiskSize(String validDiskSize){
+         this.validDiskSize = validDiskSize;
+         return this;
+      }
+
+      /**
+       * @see DiskType#getDeprecated()
+       */
+      public Builder deprecated(Deprecated deprecated){
+         this.deprecated = deprecated;
+         return this;
+      }
+
+      @Override
+      protected Builder self() {
+         return this;
+      }
+
+      public DiskType build() {
+         return new DiskType(id, creationTimestamp, selfLink, name, description,
+               validDiskSize, deprecated, zone, defaultDiskSizeGb);
+      }
+
+      public Builder fromDiskType(DiskType in) {
+         return super.fromResource(in).zone(in.getZone()).defaultDiskSizeGb(in
+                 .getDefaultDiskSizeGb()).validDiskSize(in.getValidDiskSize().orNull())
+                 .deprecated(in.getDeprecated().orNull());
+      }
+   }
+}

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Resource.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Resource.java
@@ -47,6 +47,8 @@ public class Resource {
       ADDRESS_LIST,
       DISK,
       DISK_LIST,
+      DISK_TYPE,
+      DISK_TYPE_LIST,
       FIREWALL,
       FIREWALL_LIST,
       IMAGE,

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/DiskTypeApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/DiskTypeApi.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.features;
+
+import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.COMPUTE_READONLY_SCOPE;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
+import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
+import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.domain.DiskType;
+import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.functions.internal.ParseDiskTypes;
+import org.jclouds.googlecomputeengine.options.ListOptions;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.oauth.v2.config.OAuthScopes;
+import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
+import org.jclouds.rest.annotations.Fallback;
+import org.jclouds.rest.annotations.RequestFilters;
+import org.jclouds.rest.annotations.ResponseParser;
+import org.jclouds.rest.annotations.SkipEncoding;
+import org.jclouds.rest.annotations.Transform;
+
+/**
+ * Provides access to DiskTypes via their REST API.
+ *
+ * @see <a href="https://cloud.google.com/compute/docs/reference/v1/diskTypes"/>
+ */
+@SkipEncoding({'/', '='})
+@RequestFilters(OAuthAuthenticationFilter.class)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface DiskTypeApi {
+
+      /**
+       * Returns the specified disk type resource.
+       *
+       * @param zone            the name of the zone the disk type is in
+       * @param diskType       name of the disk type resource to return.
+       * @return If successful, this method returns a DiskType resource
+       */
+      @Named("DiskTypes:get")
+      @GET
+      @Path("/zones/{zone}/diskTypes/{diskType}")
+      @OAuthScopes(COMPUTE_READONLY_SCOPE)
+      @Fallback(NullOnNotFoundOr404.class)
+      DiskType getInZone(@PathParam("zone") String zone, @PathParam("diskType") String diskTypeName);
+
+      /**
+       * @see DiskTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
+       */
+      @Named("DiskTypes:list")
+      @GET
+      @Path("/zones/{zone}/diskTypes")
+      @OAuthScopes(COMPUTE_READONLY_SCOPE)
+      @ResponseParser(ParseDiskTypes.class)
+      @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
+      ListPage<DiskType> listFirstPageInZone(@PathParam("zone") String zone);
+
+      /**
+       * @see DiskTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
+       */
+      @Named("DiskTypes:list")
+      @GET
+      @Path("/zones/{zone}/diskType")
+      @OAuthScopes(COMPUTE_READONLY_SCOPE)
+      @ResponseParser(ParseDiskTypes.class)
+      @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
+      ListPage<DiskType> listAtMarkerInZone(@PathParam("zone") String zone, @QueryParam("pageToken") @Nullable String marker);
+
+      /**
+       * Retrieves the list of disk type resources available to the specified project.
+       * By default the list as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has not
+       * been set.
+       *
+       * @param zone        The name of the zone to list in.
+       * @param marker      marks the beginning of the next list page
+       * @param listOptions listing options
+       * @return a page of the list
+       * @see ListOptions
+       * @see org.jclouds.googlecomputeengine.domain.ListPage
+       */
+      @Named("DiskTypes:list")
+      @GET
+      @Path("/zones/{zone}/diskTypes")
+      @OAuthScopes(COMPUTE_READONLY_SCOPE)
+      @ResponseParser(ParseDiskTypes.class)
+      @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
+      ListPage<DiskType> listAtMarkerInZone(@PathParam("zone") String zone,
+                                            @QueryParam("pageToken") @Nullable String marker,
+                                            ListOptions listOptions);
+
+      /**
+       * @see DiskTypeApi#listInZone(String, org.jclouds.googlecomputeengine.options.ListOptions)
+       */
+      @Named("DiskTypes:list")
+      @GET
+      @Path("/zones/{zone}/diskTypes")
+      @OAuthScopes(COMPUTE_READONLY_SCOPE)
+      @ResponseParser(ParseDiskTypes.class)
+      @Transform(ParseDiskTypes.ToPagedIterable.class)
+      @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
+      PagedIterable<DiskType> listInZone(@PathParam("zone") String zone);
+
+      /**
+       * @see DiskTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
+       *
+       * @param zone the zone to list in
+       * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
+       * @see PagedIterable
+       */
+      @Named("DiskTypes:list")
+      @GET
+      @Path("/zones/{zone}/diskTypes")
+      @OAuthScopes(COMPUTE_READONLY_SCOPE)
+      @ResponseParser(ParseDiskTypes.class)
+      @Transform(ParseDiskTypes.ToPagedIterable.class)
+      @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
+      PagedIterable<DiskType> listInZone(@PathParam("zone") String zone, ListOptions listOptions);
+
+}

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/ParseDiskTypes.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/ParseDiskTypes.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.functions.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.inject.Inject;
+
+import org.jclouds.collect.IterableWithMarker;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
+import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.DiskType;
+import org.jclouds.googlecomputeengine.options.ListOptions;
+import org.jclouds.http.functions.ParseJson;
+import org.jclouds.json.Json;
+
+import com.google.common.base.Function;
+import com.google.inject.TypeLiteral;
+
+public class ParseDiskTypes extends ParseJson<ListPage<DiskType>> {
+
+   @Inject
+   public ParseDiskTypes(Json json) {
+      super(json, new TypeLiteral<ListPage<DiskType>>() {});
+   }
+
+   public static class ToPagedIterable extends BaseWithZoneToPagedIterable<DiskType, ToPagedIterable> {
+
+      private final GoogleComputeEngineApi api;
+
+      @Inject
+      protected ToPagedIterable(GoogleComputeEngineApi api) {
+         this.api = checkNotNull(api, "api");
+      }
+
+      @Override
+      protected Function<Object, IterableWithMarker<DiskType>> fetchNextPage(final String project,
+                                                                             final String zone,
+                                                                             final ListOptions options) {
+         return new Function<Object, IterableWithMarker<DiskType>>() {
+
+            @Override
+            public IterableWithMarker<DiskType> apply(Object input) {
+               return api.getDiskTypeApiForProject(project)
+                       .listAtMarkerInZone(zone, input.toString(), options);
+            }
+         };
+      }
+   }
+}

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
@@ -43,7 +43,6 @@ public class DiskApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    @Test(groups = "live")
    public void testInsertDisk() {
       assertZoneOperationDoneSucessfully(api().createInZone(DISK_NAME, sizeGb, DEFAULT_ZONE_NAME), TIME_WAIT);
-
    }
 
    @Test(groups = "live", dependsOnMethods = "testInsertDisk")

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskTypeApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskTypeApiExpectTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.features;
+
+import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.COMPUTE_READONLY_SCOPE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineApiExpectTest;
+import org.jclouds.googlecomputeengine.parse.ParseDiskTypeListTest;
+import org.jclouds.googlecomputeengine.parse.ParseDiskTypeTest;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit")
+public class DiskTypeApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
+
+   public static final HttpRequest LIST_DISK_TYPES_REQUEST = HttpRequest
+           .builder()
+           .method("GET")
+           .endpoint("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/diskTypes")
+           .addHeader("Accept", "application/json")
+           .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+   public static final HttpResponse LIST_DISK_TYPES_RESPONSE = HttpResponse.builder()
+           .statusCode(200)
+           .payload(staticPayloadFromResource("/disktype_list.json"))
+           .build();
+
+   public static final HttpRequest LIST_CENTRAL1B_DISK_TYPES_REQUEST = HttpRequest
+           .builder()
+           .method("GET")
+           .endpoint("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-b/diskTypes")
+           .addHeader("Accept", "application/json")
+           .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+   public static final HttpResponse LIST_CENTRAL1B_DISK_TYPES_RESPONSE = HttpResponse.builder()
+           .statusCode(200)
+           .payload(staticPayloadFromResource("/disktype_list_central1b.json"))
+           .build();
+
+   public void testGetDiskTypeResponseIs2xx() throws Exception {
+      HttpRequest get = HttpRequest
+              .builder()
+              .method("GET")
+              .endpoint("https://www.googleapis" +
+                      ".com/compute/v1/projects/myproject/zones/us-central1-a/diskTypes/pd-standard")
+              .addHeader("Accept", "application/json")
+              .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+      HttpResponse operationResponse = HttpResponse.builder().statusCode(200)
+              .payload(payloadFromResource("/disktype.json")).build();
+
+      DiskTypeApi diskTypeApi = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
+              TOKEN_RESPONSE, get, operationResponse).getDiskTypeApiForProject("myproject");
+
+      assertEquals(diskTypeApi.getInZone("us-central1-a", "pd-standard"),
+              new ParseDiskTypeTest().expected());
+   }
+
+   public void testGetDiskTypeResponseIs4xx() throws Exception {
+      HttpRequest get = HttpRequest
+              .builder()
+              .method("GET")
+              .endpoint("https://www.googleapis" +
+                      ".com/compute/v1/projects/myproject/zones/us-central1-a/diskTypes/pd-standard")
+              .addHeader("Accept", "application/json")
+              .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+      HttpResponse operationResponse = HttpResponse.builder().statusCode(404).build();
+
+      DiskTypeApi diskTypeApi = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
+              TOKEN_RESPONSE, get, operationResponse).getDiskTypeApiForProject("myproject");
+
+      assertNull(diskTypeApi.getInZone("us-central1-a", "pd-standard"));
+   }
+
+   public void testListDiskTypeNoOptionsResponseIs2xx() throws Exception {
+
+      DiskTypeApi diskTypeApi = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
+              TOKEN_RESPONSE, LIST_DISK_TYPES_REQUEST, LIST_DISK_TYPES_RESPONSE).getDiskTypeApiForProject
+              ("myproject");
+
+      assertEquals(diskTypeApi.listFirstPageInZone("us-central1-a").toString(),
+              new ParseDiskTypeListTest().expected().toString());
+   }
+
+   public void testLisOperationWithPaginationOptionsResponseIs4xx() {
+
+      HttpResponse operationResponse = HttpResponse.builder().statusCode(404).build();
+
+      DiskTypeApi diskTypeApi = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
+              TOKEN_RESPONSE, LIST_DISK_TYPES_REQUEST, operationResponse).getDiskTypeApiForProject("myproject");
+
+      assertTrue(diskTypeApi.listInZone("us-central1-a").concat().isEmpty());
+   }
+}

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskTypeApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskTypeApiLiveTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.features;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.jclouds.collect.IterableWithMarker;
+import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.domain.DiskType;
+import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineApiLiveTest;
+import org.jclouds.googlecomputeengine.options.ListOptions;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+
+public class DiskTypeApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
+
+   private DiskType diskType;
+
+   private DiskTypeApi api() {
+      return api.getDiskTypeApiForProject(userProject.get());
+   }
+
+   @Test(groups = "live")
+   public void testDiskType() {
+
+      PagedIterable<DiskType> diskTypes = api().listInZone(DEFAULT_ZONE_NAME, new ListOptions.Builder()
+              .maxResults(1));
+
+      Iterator<IterableWithMarker<DiskType>> pageIterator = diskTypes.iterator();
+      assertTrue(pageIterator.hasNext());
+
+      IterableWithMarker<DiskType> singlePageIterator = pageIterator.next();
+      List<DiskType> diskTypeAsList = Lists.newArrayList(singlePageIterator);
+
+      assertSame(diskTypeAsList.size(), 1);
+
+      this.diskType = Iterables.getOnlyElement(diskTypeAsList);
+   }
+
+   @Test(groups = "live", dependsOnMethods = "testDiskType")
+   public void testGetDiskType() {
+      DiskType diskType = api().getInZone(DEFAULT_ZONE_NAME, this.diskType.getName());
+      assertNotNull(diskType);
+      assertDiskTypeEquals(diskType, this.diskType);
+   }
+
+   private void assertDiskTypeEquals(DiskType result, DiskType expected) {
+      assertEquals(result.getName(), expected.getName());
+      assertEquals(result.getValidDiskSize(), expected.getValidDiskSize());
+      assertEquals(result.getZone(), expected.getZone());
+      assertEquals(result.getDefaultDiskSizeGb(), expected.getDefaultDiskSizeGb());
+      assertEquals(result.getSelfLink(), expected.getSelfLink());
+   }
+}

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTypeListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTypeListTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.parse;
+
+import static org.jclouds.googlecomputeengine.domain.Resource.Kind.DISK_TYPE_LIST;
+
+import java.net.URI;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.date.internal.SimpleDateFormatDateService;
+import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.DiskType;
+import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
+
+public class ParseDiskTypeListTest extends BaseGoogleComputeEngineParseTest<ListPage<DiskType>> {
+
+   @Override
+   public String resource() {
+      return "/disktype_list.json";
+   }
+
+   @Override
+   @Consumes(MediaType.APPLICATION_JSON)
+   public ListPage<DiskType> expected() {
+      SimpleDateFormatDateService dateService = new SimpleDateFormatDateService();
+      return ListPage.<DiskType>builder()
+              .kind(DISK_TYPE_LIST)
+              .addItem(DiskType.builder()
+                      .creationTimestamp(dateService.iso8601DateParse("2014-06-02T11:07:28.530-07:00"))
+                      .name("pd-standard")
+                      .description("Standard Persistent Disk")
+                      .validDiskSize("10GB-10TB")
+                      .zone("https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a")
+                      .selfLink(URI.create("https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes/pd-standard"))
+                      .defaultDiskSizeGb(500)
+                      .build())
+              .addItem(DiskType.builder()
+                      .creationTimestamp(dateService.iso8601DateParse("2014-06-02T11:07:28.529-07:00"))
+                      .name("pd-ssd")
+                      .description("SSD Persistent Disk")
+                      .validDiskSize("10GB-1TB")
+                      .zone("https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a")
+                      .selfLink(URI.create("https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes/pd-ssd"))
+                      .defaultDiskSizeGb(100)
+                      .build())
+              .build();
+   }
+}

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTypeTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTypeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.parse;
+
+import java.net.URI;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.date.internal.SimpleDateFormatDateService;
+import org.jclouds.googlecomputeengine.domain.DiskType;
+import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
+
+public class ParseDiskTypeTest extends BaseGoogleComputeEngineParseTest<DiskType> {
+
+
+   @Override
+   public String resource() {
+      return "/disktype.json";
+   }
+
+   @Override
+   @Consumes(MediaType.APPLICATION_JSON)
+   public DiskType expected() {
+      SimpleDateFormatDateService dateService = new SimpleDateFormatDateService();
+      return DiskType.builder()
+              .creationTimestamp(dateService.iso8601DateParse("2014-06-02T11:07:28.529-07:00"))
+              .name("pd-ssd")
+              .description("SSD Persistent Disk")
+              .validDiskSize("10GB-1TB")
+              .zone("https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a")
+              .selfLink(URI.create("https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes/pd-ssd"))
+              .defaultDiskSizeGb(100)
+              .build();
+   }
+}

--- a/google-compute-engine/src/test/resources/disktype.json
+++ b/google-compute-engine/src/test/resources/disktype.json
@@ -1,0 +1,11 @@
+{
+ "kind": "compute#diskType",
+ "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+ "name": "pd-ssd",
+ "description": "SSD Persistent Disk",
+ "validDiskSize": "10GB-1TB",
+ "zone": "https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a",
+ "selfLink": "https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes/pd-ssd",
+ "defaultDiskSizeGb": "100"
+}
+

--- a/google-compute-engine/src/test/resources/disktype_list.json
+++ b/google-compute-engine/src/test/resources/disktype_list.json
@@ -1,0 +1,27 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+   "name": "pd-standard",
+   "description": "Standard Persistent Disk",
+   "validDiskSize": "10GB-10TB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes/pd-standard",
+   "defaultDiskSizeGb": "500"
+  },
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+   "name": "pd-ssd",
+   "description": "SSD Persistent Disk",
+   "validDiskSize": "10GB-1TB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes/pd-ssd",
+   "defaultDiskSizeGb": "100"
+  }
+ ]
+}
+

--- a/google-compute-engine/src/test/resources/disktype_list_central1b.json
+++ b/google-compute-engine/src/test/resources/disktype_list_central1b.json
@@ -1,0 +1,17 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+   "name": "pd-standard",
+   "description": "Standard Persistent Disk",
+   "validDiskSize": "10GB-10TB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes/pd-standard",
+   "defaultDiskSizeGb": "500"
+  }
+ ]
+}
+


### PR DESCRIPTION
I figured before adding support for SSDs it makes sense to add coverage of the DiskTypes Api. 

DiskTypes Api Documentation: https://cloud.google.com/compute/docs/reference/latest/diskTypes 

The implementation is very similar to MachineTypes Api. Refactoring redundancies may be desirable in the future. 

Also like MachineTypes this only covers the "get" and "list" operations and does not yet cover the "aggregatedList" operation.  
