### PR TITLE
Adding SSD support

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceAdapter.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceAdapter.java
@@ -32,6 +32,7 @@ import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.OPERA
 import static org.jclouds.googlecomputeengine.domain.Instance.NetworkInterface.AccessConfig.Type;
 import static org.jclouds.googlecomputeengine.predicates.InstancePredicates.isBootDisk;
 import static org.jclouds.util.Predicates2.retry;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +70,7 @@ import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.domain.SlashEncodedIds;
 import org.jclouds.googlecomputeengine.domain.Zone;
 import org.jclouds.googlecomputeengine.features.InstanceApi;
+import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.logging.Logger;
 
@@ -239,11 +241,12 @@ public class GoogleComputeEngineServiceAdapter implements ComputeServiceAdapter<
 
       String diskName = instanceName + "-" + GCE_BOOT_DISK_SUFFIX;
 
+      DiskCreationOptions diskCreationOptions = new DiskCreationOptions().sourceImage(imageUri);
       Operation diskOperation = api.getDiskApiForProject(userProject.get())
-                                   .createFromImageWithSizeInZone(imageUri.toString(),
-                                                                  diskName,
-                                                                  diskSize,
-                                                                  template.getLocation().getId());
+                                   .createInZone(diskName,
+                                                 diskSize,
+                                                 template.getLocation().getId(),
+                                                 diskCreationOptions);
 
       waitOperationDone(diskOperation);
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Disk.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Disk.java
@@ -17,14 +17,18 @@
 package org.jclouds.googlecomputeengine.domain;
 
 import static com.google.common.base.Objects.equal;
+import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.beans.ConstructorProperties;
 import java.net.URI;
 import java.util.Date;
 
+import org.jclouds.javax.annotation.Nullable;
+
 import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
 
 /**
  * A persistent disk resource
@@ -35,15 +39,17 @@ import com.google.common.base.MoreObjects;
 public final class Disk extends AbstractDisk {
 
    private final URI zone;
+   private final Optional<URI> type;
 
    @ConstructorProperties({
            "id", "creationTimestamp", "selfLink", "name", "description", "sizeGb", "zone",
-           "status"
+           "status", "type"
    })
    private Disk(String id, Date creationTimestamp, URI selfLink, String name, String description,
-                Integer sizeGb, URI zone, String status) {
+                Integer sizeGb, URI zone, String status, @Nullable URI type) {
       super(Kind.DISK, id, creationTimestamp, selfLink, name, description, sizeGb, status);
       this.zone = checkNotNull(zone, "zone of %s", name);
+      this.type = fromNullable(type);
    }
 
    /**
@@ -51,6 +57,13 @@ public final class Disk extends AbstractDisk {
     */
    public URI getZone() {
       return zone;
+   }
+
+   /**
+    * @return URL of the disk type resource describing which disk type
+    */
+   public Optional<URI> getType(){
+      return type;
    }
 
    /**
@@ -95,12 +108,21 @@ public final class Disk extends AbstractDisk {
    public static final class Builder extends AbstractDisk.Builder<Builder> {
 
       private URI zone;
+      private URI type;
 
       /**
        * @see Disk#getZone()
        */
       public Builder zone(URI zone) {
          this.zone = zone;
+         return this;
+      }
+
+      /**
+       * @see Disk#getType()
+       */
+      public Builder type(URI type){
+         this.type = type;
          return this;
       }
 
@@ -111,12 +133,13 @@ public final class Disk extends AbstractDisk {
 
       public Disk build() {
          return new Disk(super.id, super.creationTimestamp, super.selfLink, super.name,
-                 super.description, super.sizeGb, zone, super.status);
+                 super.description, super.sizeGb, zone, super.status, type);
       }
 
       public Builder fromDisk(Disk in) {
          return super.fromAbstractDisk(in)
-                 .zone(in.getZone());
+                 .zone(in.getZone())
+                 .type(in.getType().orNull());
       }
 
    }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/DiskApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/DiskApi.java
@@ -38,6 +38,8 @@ import org.jclouds.googlecomputeengine.domain.Disk;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.functions.internal.ParseDisks;
+import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
+import org.jclouds.googlecomputeengine.handlers.DiskCreationBinder;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
@@ -97,13 +99,13 @@ public interface DiskApi {
                           @PathParam("zone") String zone);
 
    /**
-    * Creates a persistent disk resource from the specified image, in the specified project,
-    * specifying the size of the disk.
+    * Creates a persistent disk resource, in the specified project,
+    * specifying the size of the disk and other options.
     *
-    * @param sourceImage fully qualified URL for the image to be copied.
     * @param diskName the name of disk.
     * @param sizeGb   the size of the disk
     * @param zone     the name of the zone where the disk is to be created.
+    * @param diskCreationOption the options of the disk to create.
     * @return an Operation resource. To check on the status of an operation, poll the Operations resource returned to
     *         you, and look for the status field.
     */
@@ -113,32 +115,11 @@ public interface DiskApi {
    @Produces(MediaType.APPLICATION_JSON)
    @Path("/zones/{zone}/disks")
    @OAuthScopes({COMPUTE_SCOPE})
-   @MapBinder(BindToJsonPayload.class)
-   Operation createFromImageWithSizeInZone(@QueryParam("sourceImage") String sourceImage,
-                                           @PayloadParam("name") String diskName,
-                                           @PayloadParam("sizeGb") int sizeGb,
-                                           @PathParam("zone") String zone);
-
-   /**
-    * Creates a persistent disk resource from the specified image, in the specified project,
-    * with the default disk size.
-    *
-    * @param sourceImage fully qualified URL for the image to be copied.
-    * @param diskName the name of disk.
-    * @param zone     the name of the zone where the disk is to be created.
-    * @return an Operation resource. To check on the status of an operation, poll the Operations resource returned to
-    *         you, and look for the status field.
-    */
-   @Named("Disks:insert")
-   @POST
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Produces(MediaType.APPLICATION_JSON)
-   @Path("/zones/{zone}/disks")
-   @OAuthScopes({COMPUTE_SCOPE})
-   @MapBinder(BindToJsonPayload.class)
-   Operation createFromImageInZone(@QueryParam("sourceImage") String sourceImage,
-                                   @PayloadParam("name") String diskName,
-                                   @PathParam("zone") String zone);
+   @MapBinder(DiskCreationBinder.class)
+   Operation createInZone(@PayloadParam("name") String diskName,
+                          @PayloadParam("sizeGb") int sizeGb,
+                          @PathParam("zone") String zone,
+                          @PayloadParam("options") DiskCreationOptions diskCreationOptions);
 
    /**
     * Deletes the specified persistent disk resource.

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/handlers/DiskCreationBinder.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/handlers/DiskCreationBinder.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.handlers;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.json.Json;
+import org.jclouds.rest.binders.BindToJsonPayload;
+
+import com.google.inject.Inject;
+
+public class DiskCreationBinder extends BindToJsonPayload {
+
+   @Inject
+   public DiskCreationBinder(Json jsonBinder) {
+      super(jsonBinder);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public <R extends HttpRequest> R bindToRequest(R request, Map<String, Object> postParams) {
+      DiskCreationOptions options = (DiskCreationOptions) checkNotNull(postParams.get("options"), "diskCreationOptions");
+      String name = (String) checkNotNull(postParams.get("name"), "name");
+      int sizeGb = (int) checkNotNull(postParams.get("sizeGb"), "sizeGb");
+      DiskCreationBinderHelper diskCreationOptionsExtended = new DiskCreationBinderHelper(name, sizeGb, options);
+      return super.bindToRequest(request, diskCreationOptionsExtended);
+   }
+
+   private class DiskCreationBinderHelper{
+
+      /**
+       * Values used to bind DiskCreationOptions to json request.
+       */
+      @SuppressWarnings("unused")
+      private String name;
+      @SuppressWarnings("unused")
+      private int sizeGb;
+      @SuppressWarnings("unused")
+      private URI type;
+      @SuppressWarnings("unused")
+      private URI sourceImage;
+      @SuppressWarnings("unused")
+      private URI sourceSnapshot;
+
+      private DiskCreationBinderHelper(String name, int sizeGb, DiskCreationOptions diskCreationOptions){
+         this.name = name;
+         this.sizeGb = sizeGb;
+         this.type = diskCreationOptions.getType();
+         this.sourceImage = diskCreationOptions.getSourceImage();
+         this.sourceSnapshot = diskCreationOptions.getSourceSnapshot();
+      }
+   }
+}

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/DiskCreationOptions.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/DiskCreationOptions.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.options;
+
+import java.net.URI;
+
+/**
+ * Options for attaching disks to instances.
+ *
+ * @see <a href="https://cloud.google.com/compute/docs/reference/latest/disks/insert"/>
+ */
+public class DiskCreationOptions {
+
+   /**
+    *  DiskCreationBinder extends this class to add name and sizeGb
+    */
+   private URI type;
+   private URI sourceImage;
+   private URI sourceSnapshot;
+
+   /**
+    * The disk type, fully qualified URL for the disk type.
+    *
+    * @return the disk type
+    */
+   public URI getType(){
+      return type;
+   }
+
+   /**
+    * The source image
+    *
+    * @return sourceImage, fully qualified URL for the image to be copied.
+    */
+   public URI getSourceImage(){
+      return sourceImage;
+   }
+
+   /**
+    * The source snapshot
+    *
+    * @return sourceSnapshot, fully qualified URL for the snapshot to be copied.
+    */
+   public URI getSourceSnapshot(){
+      return sourceSnapshot;
+   }
+
+   /**
+    * @see DiskCreationOptions#getType()
+    */
+   public DiskCreationOptions type(URI type){
+      this.type = type;
+      return this;
+   }
+
+   /**
+    * @see DiskCreationOptions#getSourceImage()
+    */
+   public DiskCreationOptions sourceImage(URI sourceImage){
+      this.sourceImage = sourceImage;
+      return this;
+   }
+
+   /**
+    * @see DiskCreationOptions#getSourceSnapshot()
+    */
+   public DiskCreationOptions sourceSnapshot(URI sourceSnapshot){
+      this.sourceSnapshot = sourceSnapshot;
+      return this;
+   }
+}

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
@@ -182,12 +182,12 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
       return HttpRequest
               .builder()
               .method("POST")
-              .endpoint("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/disks"
-                                + "?sourceImage=https%3A//www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718")
+              .endpoint("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/disks")
               .addHeader("Accept", "application/json")
               .addHeader("Authorization", "Bearer " + TOKEN)
               .payload(payloadFromStringWithContentType("{\"name\":\"" + instanceName + "-" + GCE_BOOT_DISK_SUFFIX + "\","
-                                                        + "\"sizeGb\":10}",
+                                                        + "\"sizeGb\":10,"
+                                                        + "\"sourceImage\":\"https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140718\"}",
                                                         MediaType.APPLICATION_JSON)).build();
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
@@ -19,11 +19,13 @@ package org.jclouds.googlecomputeengine.features;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import java.net.URI;
 import java.util.List;
 
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.googlecomputeengine.domain.Disk;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineApiLiveTest;
+import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.testng.annotations.Test;
 
@@ -33,6 +35,7 @@ import com.google.common.collect.Lists;
 public class DiskApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    public static final String DISK_NAME = "disk-api-live-test-disk";
+   public static final String SSD_DISK_NAME = "disk-api-live-test-disk-ssd";
    public static final int TIME_WAIT = 30;
    public static final int sizeGb = 1;
 
@@ -79,4 +82,31 @@ public class DiskApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
       assertEquals(result.getZone(), getDefaultZoneUrl(userProject.get()));
    }
 
+   @Test(groups = "live")
+   public void testInsertSSDDisk() {
+      URI diskType = getDiskTypeUrl(userProject.get(), DEFAULT_ZONE_NAME, "pd-ssd");
+      DiskCreationOptions diskCreationOptions = new DiskCreationOptions().type(diskType);
+      assertZoneOperationDoneSucessfully(api().createInZone(SSD_DISK_NAME, sizeGb, DEFAULT_ZONE_NAME, diskCreationOptions), TIME_WAIT);
+   }
+
+   @Test(groups = "live", dependsOnMethods = "testInsertSSDDisk")
+   public void testGetSSDDisk() {
+
+      Disk disk = api().getInZone(DEFAULT_ZONE_NAME, SSD_DISK_NAME);
+      assertNotNull(disk);
+      assertSSDDiskEquals(disk);
+   }
+
+   @Test(groups = "live", dependsOnMethods = "testGetSSDDisk")
+   public void testDeleteSSDDisk() {
+
+      assertZoneOperationDoneSucessfully(api().deleteInZone(DEFAULT_ZONE_NAME, SSD_DISK_NAME), TIME_WAIT);
+   }
+
+   private void assertSSDDiskEquals(Disk result) {
+      assertEquals(result.getName(), SSD_DISK_NAME);
+      assertEquals(result.getSizeGb(), sizeGb);
+      assertEquals(result.getZone(), getDefaultZoneUrl(userProject.get()));
+      assertEquals(result.getType().orNull(), getDiskTypeUrl(userProject.get(), DEFAULT_ZONE_NAME, "pd-ssd"));
+   }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
@@ -36,6 +36,7 @@ import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineApiLiveTe
 import org.jclouds.googlecomputeengine.options.AttachDiskOptions;
 import org.jclouds.googlecomputeengine.options.AttachDiskOptions.DiskMode;
 import org.jclouds.googlecomputeengine.options.AttachDiskOptions.DiskType;
+import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -61,6 +62,7 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    private static final String ATTACH_DISK_NAME = "instance-api-live-test-attach-disk";
    private static final String ATTACH_DISK_DEVICE_NAME = "attach-disk-1";
 
+   private static final int DEFAULT_DISK_SIZE_GB = 10;
    private static final int TIME_WAIT = 600;
 
    private InstanceTemplate instance;
@@ -110,16 +112,14 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
       assertGlobalOperationDoneSucessfully(api.getNetworkApiForProject(userProject.get()).createInIPv4Range
               (INSTANCE_NETWORK_NAME, IPV4_RANGE), TIME_WAIT);
 
-
+      DiskCreationOptions diskCreationOptions = new DiskCreationOptions().sourceImage(instance.getImage());
       assertZoneOperationDoneSucessfully(api.getDiskApiForProject(userProject.get())
-                                        .createFromImageInZone(instance.getImage().toString(),
-                                                               BOOT_DISK_NAME,
-                                                               DEFAULT_ZONE_NAME),
+                                        .createInZone(BOOT_DISK_NAME, DEFAULT_DISK_SIZE_GB, DEFAULT_ZONE_NAME, diskCreationOptions),
                                          TIME_WAIT);
 
 
       assertZoneOperationDoneSucessfully(diskApi().createInZone
-              ("instance-live-test-disk", 10, DEFAULT_ZONE_NAME), TIME_WAIT);
+              ("instance-live-test-disk", DEFAULT_DISK_SIZE_GB, DEFAULT_ZONE_NAME), TIME_WAIT);
 
       assertZoneOperationDoneSucessfully(api().createInZone(INSTANCE_NAME, DEFAULT_ZONE_NAME, instance), TIME_WAIT);
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/handlers/DiskCreationBinderTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/handlers/DiskCreationBinderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.handlers;
+
+import static org.testng.Assert.assertEquals;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineExpectTest;
+import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.json.Json;
+import org.jclouds.json.internal.GsonWrapper;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+
+/**
+ * Tests behavior of {@code BindToJsonPayload}
+ */
+@Test(groups = "unit", testName = "DiskCreationBinderTest")
+public class DiskCreationBinderTest extends BaseGoogleComputeEngineExpectTest<Object>{
+
+   private static final String FAKE_SOURCE_IMAGE = "https://www.googleapis.com/compute/v1/projects/" +
+                                       "debian-cloud/global/images/backports-debian-7-wheezy-v20141017";
+
+   Json json = new GsonWrapper(new Gson());
+ 
+   @Test
+   public void testMap() throws SecurityException, NoSuchMethodException {
+      DiskCreationBinder binder = new DiskCreationBinder(json);
+      DiskCreationOptions diskCreationOptions = new DiskCreationOptions().sourceImage(URI.create(FAKE_SOURCE_IMAGE));
+
+      HttpRequest request = HttpRequest.builder().method("GET").endpoint("http://momma").build();
+      Map<String, Object> postParams = ImmutableMap.of("name", "testName", "sizeGb", 15, "options", diskCreationOptions);
+
+      binder.bindToRequest(request, postParams);
+
+      assertEquals(request.getPayload().getRawContent(),
+            "{\"name\":\"testName\",\"sizeGb\":15,\"sourceImage\":\"" + FAKE_SOURCE_IMAGE + "\"}");
+      assertEquals(request.getPayload().getContentMetadata().getContentType(), "application/json");
+
+   }
+
+   @Test(expectedExceptions = NullPointerException.class)
+   public void testNullIsBad() {
+      DiskCreationBinder binder = new DiskCreationBinder(json);
+      binder.bindToRequest(HttpRequest.builder().method("GET").endpoint("http://momma").build(), null);
+   }
+
+}

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiLiveTest.java
@@ -60,6 +60,9 @@ public class BaseGoogleComputeEngineApiLiveTest extends BaseApiLiveTest<GoogleCo
 
    protected static final String IMAGE_API_URL_SUFFIX = "/global/images/";
 
+   protected static final String DISK_TYPE_API_URL_SUFFIX = "/diskTypes/";
+   protected static final String DEFAULT_DISK_NAME = "pd-standard";
+
    protected static final String GOOGLE_PROJECT = "google";
 
    protected Supplier<String> userProject;
@@ -116,6 +119,10 @@ public class BaseGoogleComputeEngineApiLiveTest extends BaseApiLiveTest<GoogleCo
 
    protected Operation waitZoneOperationDone(Operation operation, long maxWaitSeconds) {
       return waitOperationDone(zoneOperationDonePredicate, operation, maxWaitSeconds);
+   }
+
+   protected URI getDiskTypeUrl(String project, String zone, String diskType){
+      return URI.create(API_URL_PREFIX + project + ZONE_API_URL_SUFFIX + zone + DISK_TYPE_API_URL_SUFFIX + diskType);
    }
 
    protected URI getDefaultZoneUrl(String project) {

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTest.java
@@ -45,6 +45,7 @@ public class ParseDiskTest extends BaseGoogleComputeEngineParseTest<Disk> {
               .sizeGb(1)
               .zone(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a"))
               .status("READY")
+              .type(URI.create("https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/diskTypes/pd-ssd"))
               .build();
    }
 }

--- a/google-compute-engine/src/test/resources/disk_get.json
+++ b/google-compute-engine/src/test/resources/disk_get.json
@@ -6,5 +6,6 @@
    "name": "testimage1",
    "sizeGb": "1",
    "zone": "https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a",
-   "status": "READY"
+   "status": "READY",
+   "type": "https://www.googleapis.com/compute/v1/projects/studied-point-720/zones/us-central1-a/diskTypes/pd-standard"
 }

--- a/google-compute-engine/src/test/resources/disk_insert_sourceImage.json
+++ b/google-compute-engine/src/test/resources/disk_insert_sourceImage.json
@@ -1,0 +1,1 @@
+{"name":"testimage1","sizeGb":1,"sourceImage":"https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/images/foo"}

--- a/google-compute-engine/src/test/resources/disk_insert_ssd.json
+++ b/google-compute-engine/src/test/resources/disk_insert_ssd.json
@@ -1,0 +1,1 @@
+{"name":"testimage1","sizeGb":1,"type":"https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/diskTypes/pd-ssd"}


### PR DESCRIPTION
Adds the ability to specify a disk type when creating a disk.

Impact: users are able to use SSDs. 
