### PR TITLE
JCLOUDS-649: Added image creation from pd, changed rawDisk to Optional<T>

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Image.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Image.java
@@ -39,7 +39,7 @@ import com.google.common.base.Optional;
 public final class Image extends Resource {
 
    private final String sourceType;
-   private final RawDisk rawDisk;
+   private final Optional<RawDisk> rawDisk;
    private final Optional<Deprecated> deprecated;
 
    @ConstructorProperties({
@@ -50,7 +50,7 @@ public final class Image extends Resource {
                    String sourceType, RawDisk rawDisk, Deprecated deprecated) {
       super(Kind.IMAGE, id, creationTimestamp, selfLink, name, description);
       this.sourceType = checkNotNull(sourceType, "sourceType of %s", name);
-      this.rawDisk = checkNotNull(rawDisk, "rawDisk of %s", name);
+      this.rawDisk = fromNullable(rawDisk);
       this.deprecated = fromNullable(deprecated);
    }
 
@@ -64,7 +64,7 @@ public final class Image extends Resource {
    /**
     * @return the raw disk image parameters.
     */
-   public RawDisk getRawDisk() {
+   public Optional<RawDisk> getRawDisk() {
       return rawDisk;
    }
 
@@ -146,7 +146,7 @@ public final class Image extends Resource {
       public Builder fromImage(Image in) {
          return super.fromResource(in)
                  .sourceType(in.getSourceType())
-                 .rawDisk(in.getRawDisk())
+                 .rawDisk(in.getRawDisk().orNull())
                  .deprecated(in.getDeprecated().orNull());
       }
 
@@ -188,7 +188,7 @@ public final class Image extends Resource {
       }
 
       /**
-       * @return an optional SHA1 checksum of the disk image before unpackaging; provided by the client when the disk
+       * @return an optional SHA1 checksum of the disk image before unpacking; provided by the client when the disk
        *         image is created.
        */
       public Optional<String> getSha1Checksum() {

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ImageApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ImageApi.java
@@ -23,8 +23,10 @@ import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
@@ -41,10 +43,13 @@ import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
 import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
 import org.jclouds.rest.annotations.Fallback;
+import org.jclouds.rest.annotations.MapBinder;
+import org.jclouds.rest.annotations.PayloadParam;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.SkipEncoding;
 import org.jclouds.rest.annotations.Transform;
+import org.jclouds.rest.binders.BindToJsonPayload;
 
 /**
  * Provides access to Images via their REST API.
@@ -163,5 +168,22 @@ public interface ImageApi {
    @Transform(ParseImages.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Image> list(ListOptions options);
+
+   /**
+    * Creates an image resource in the specified project from the provided persistent disk.
+    *
+    * @param imageName  the name of the created image
+    * @param sourceDisk fully qualified URL for the persistent disk to create the image from
+    * @return an Operation resource. To check on the status of an operation, poll the Operations resource returned to
+    *         you, and look for the status field.
+    */
+   @Named("Images:insert")
+   @POST
+   @Consumes(MediaType.APPLICATION_JSON)
+   @Produces(MediaType.APPLICATION_JSON)
+   @Path("/global/images")
+   @OAuthScopes(COMPUTE_SCOPE)
+   @MapBinder(BindToJsonPayload.class)
+   Operation createImageFromPD(@PayloadParam("name") String imageName, @PayloadParam("sourceDisk") String sourceDisk);
 
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.googlecomputeengine.domain.Disk;
-import org.jclouds.googlecomputeengine.domain.Project;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineApiLiveTest;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.testng.annotations.Test;
@@ -43,7 +42,6 @@ public class DiskApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    @Test(groups = "live")
    public void testInsertDisk() {
-      Project project = api.getProjectApi().get(userProject.get());
       assertZoneOperationDoneSucessfully(api().createInZone(DISK_NAME, sizeGb, DEFAULT_ZONE_NAME), TIME_WAIT);
 
    }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiLiveTest.java
@@ -21,11 +21,13 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
+import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
 
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.domain.Disk;
 import org.jclouds.googlecomputeengine.domain.Image;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineApiLiveTest;
 import org.jclouds.googlecomputeengine.options.ListOptions;
@@ -36,10 +38,24 @@ import com.google.common.collect.Lists;
 
 public class ImageApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
+   public static final String DISK_NAME = "image-api-live-test-disk";
+   public static final int TIME_WAIT = 300;
+   public static final int sizeGb = 10;
+   public static final String IMAGE_NAME = "image-api-live-test-image";
+
    private Image image;
+   private URI diskURI;
 
    private ImageApi api() {
       return api.getImageApiForProject("centos-cloud");
+   }
+
+   private ImageApi imageApi(){
+      return api.getImageApiForProject(userProject.get());
+   }
+
+   private DiskApi diskApi() {
+      return api.getDiskApiForProject(userProject.get());
    }
 
    @Test(groups = "live")
@@ -68,6 +84,36 @@ public class ImageApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    private void assertImageEquals(Image result, Image expected) {
       assertEquals(result.getName(), expected.getName());
+   }
+
+   @Test(groups = "live")
+   public void testInsertDisk() {
+      assertZoneOperationDoneSucessfully(diskApi().createInZone(DISK_NAME, sizeGb, DEFAULT_ZONE_NAME), TIME_WAIT);
+      Disk disk = diskApi().getInZone(DEFAULT_ZONE_NAME, DISK_NAME);
+      diskURI = disk.getSelfLink();
+   }
+
+   @Test(groups = "live", dependsOnMethods = "testInsertDisk")
+   public void testCreateImageFromPD(){
+      assertGlobalOperationDoneSucessfully(imageApi().createImageFromPD(IMAGE_NAME, diskURI.toString()), TIME_WAIT);
+   }
+
+   @Test(groups = "live", dependsOnMethods = "testCreateImageFromPD")
+   public void testGetCreatedImage(){
+      Image image = imageApi().get(IMAGE_NAME);
+      assertImageEquals(image);
+   }
+
+   @Test(groups = "live", dependsOnMethods = "testGetCreatedImage")
+   public void testCleanup(){
+      assertGlobalOperationDoneSucessfully(imageApi().delete(IMAGE_NAME), TIME_WAIT);
+      assertZoneOperationDoneSucessfully(diskApi().deleteInZone(DEFAULT_ZONE_NAME, DISK_NAME), TIME_WAIT);
+   }
+
+   private void assertImageEquals(Image result) {
+      assertEquals(result.getName(), IMAGE_NAME);
+      assertEquals(result.getSourceType(), "RAW");
+      assertEquals(result.getSelfLink(), getImageUrl(userProject.get(), IMAGE_NAME) );
    }
 
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiLiveTest.java
@@ -58,6 +58,8 @@ public class BaseGoogleComputeEngineApiLiveTest extends BaseApiLiveTest<GoogleCo
    protected static final String GATEWAY_API_URL_SUFFIX = "/global/gateways/";
    protected static final String DEFAULT_GATEWAY_NAME = "default-internet-gateway";
 
+   protected static final String IMAGE_API_URL_SUFFIX = "/global/images/";
+
    protected static final String GOOGLE_PROJECT = "google";
 
    protected Supplier<String> userProject;
@@ -134,6 +136,10 @@ public class BaseGoogleComputeEngineApiLiveTest extends BaseApiLiveTest<GoogleCo
 
    protected URI getGatewayUrl(String project, String gateway) {
       return URI.create(API_URL_PREFIX + project + GATEWAY_API_URL_SUFFIX + gateway);
+   }
+
+   protected URI getImageUrl(String project, String image){
+      return URI.create(API_URL_PREFIX + project + IMAGE_API_URL_SUFFIX + image);
    }
 
    protected URI getDefaultMachineTypeUrl(String project) {

--- a/google-compute-engine/src/test/resources/image_insert_from_pd.json
+++ b/google-compute-engine/src/test/resources/image_insert_from_pd.json
@@ -1,0 +1,1 @@
+{"name":"my-image","sourceDisk":"https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-a/disks/mydisk"}


### PR DESCRIPTION
Users can now create images from persistent disks. 

When images are made from PD the rawDisk attribute is not present. 
This changes Image.java to treat it as an Optional<RawDisk> instead. 
