### PR TITLE
Improved pagination in GCE

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineFallbacks.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineFallbacks.java
@@ -14,22 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.googlecomputeengine.functions.internal;
+package org.jclouds.googlecomputeengine;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.Fallbacks.valOnNotFoundOr404;
 
-import javax.ws.rs.HttpMethod;
+import org.jclouds.Fallback;
+import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.Resource.Kind;
 
-/**
- * Indicates that the annotated method responds to HTTP PATCH requests
- *
- * @see javax.ws.rs.HttpMethod
- */
-@Target({ElementType.METHOD})
-@Retention(RetentionPolicy.RUNTIME)
-@HttpMethod("PATCH")
-public @interface PATCH {
+public interface GoogleComputeEngineFallbacks {
+
+   public static final class EmptyListPageOnNotFoundOr404 implements Fallback<ListPage<Object>> {
+      public ListPage<Object> createOrPropagate(Throwable t) throws Exception {
+         // The Kind attribute is mandatory but dummy, as it will be never be used
+         return valOnNotFoundOr404(new ListPage.Empty<Object>(Kind.ADDRESS_LIST), checkNotNull(t, "throwable"));
+      }
+   }
+
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceAdapter.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceAdapter.java
@@ -393,7 +393,8 @@ public class GoogleComputeEngineServiceAdapter implements ComputeServiceAdapter<
    private LoginCredentials getFromImageAndOverrideIfRequired(org.jclouds.compute.domain.Image image,
                                                               GoogleComputeEngineTemplateOptions options) {
       LoginCredentials defaultCredentials = image.getDefaultCredentials();
-      String[] keys = defaultCredentials.getPrivateKey().split(":");
+      // Atthis point the private key must exist
+      String[] keys = defaultCredentials.getOptionalPrivateKey().get().split(":");
       String publicKey = keys[0];
       String privateKey = keys[1];
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/BuildInstanceMetadata.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/BuildInstanceMetadata.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableMap;
 public class BuildInstanceMetadata implements Function<TemplateOptions, ImmutableMap.Builder<String, String>> {
 
    @Override
-   public ImmutableMap.Builder apply(TemplateOptions input) {
+   public ImmutableMap.Builder<String, String> apply(TemplateOptions input) {
       ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
       if (input.getPublicKey() != null) {
          builder.put("sshKeys", format("%s:%s %s@localhost", checkNotNull(input.getLoginUser(),

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/FirewallToIpPermission.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/FirewallToIpPermission.java
@@ -45,7 +45,7 @@ public class FirewallToIpPermission implements Function<Firewall, Iterable<IpPer
 
    @Override
    public Iterable<IpPermission> apply(Firewall fw) {
-      ImmutableSet.Builder setBuilder = ImmutableSet.builder();
+      ImmutableSet.Builder<IpPermission> setBuilder = ImmutableSet.builder();
 
       for (Rule rule : fw.getAllowed()) {
          if (!rule.getPorts().isEmpty()) {

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/InstanceInZoneToNodeMetadata.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/InstanceInZoneToNodeMetadata.java
@@ -33,8 +33,6 @@ import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadataBuilder;
 import org.jclouds.compute.functions.GroupNamingConvention;
 import org.jclouds.domain.Location;
-import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
-import org.jclouds.googlecomputeengine.config.UserProject;
 import org.jclouds.googlecomputeengine.domain.Instance;
 import org.jclouds.googlecomputeengine.domain.InstanceInZone;
 import org.jclouds.googlecomputeengine.domain.SlashEncodedIds;
@@ -56,8 +54,6 @@ public class InstanceInZoneToNodeMetadata implements Function<InstanceInZone, No
    private final Supplier<Map<URI, ? extends Hardware>> hardwares;
    private final Supplier<Map<URI, ? extends Location>> locations;
    private final FirewallTagNamingConvention.Factory firewallTagNamingConvention;
-   private final GoogleComputeEngineApi api;
-   private final Supplier<String> userProject;
 
    @Inject
    public InstanceInZoneToNodeMetadata(Map<Instance.Status, NodeMetadata.Status> toPortableNodeStatus,
@@ -65,17 +61,13 @@ public class InstanceInZoneToNodeMetadata implements Function<InstanceInZone, No
                                  @Memoized Supplier<Map<URI, ? extends Image>> images,
                                  @Memoized Supplier<Map<URI, ? extends Hardware>> hardwares,
                                  @Memoized Supplier<Map<URI, ? extends Location>> locations,
-                                 FirewallTagNamingConvention.Factory firewallTagNamingConvention,
-                                 GoogleComputeEngineApi api,
-                                 @UserProject Supplier<String> userProject) {
+                                 FirewallTagNamingConvention.Factory firewallTagNamingConvention) {
       this.toPortableNodeStatus = toPortableNodeStatus;
       this.nodeNamingConvention = namingConvention.createWithoutPrefix();
       this.images = images;
       this.hardwares = hardwares;
       this.locations = locations;
       this.firewallTagNamingConvention = checkNotNull(firewallTagNamingConvention, "firewallTagNamingConvention");
-      this.api = checkNotNull(api, "api");
-      this.userProject = checkNotNull(userProject, "userProject");
    }
 
    @Override

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/options/GoogleComputeEngineTemplateOptions.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/options/GoogleComputeEngineTemplateOptions.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Sets;
 public class GoogleComputeEngineTemplateOptions extends TemplateOptions {
 
    private Optional<URI> network = Optional.absent();
-   private Optional<String> networkName = Optional.absent();
    private Set<Instance.ServiceAccount> serviceAccounts = Sets.newLinkedHashSet();
    private boolean enableNat = true;
    private Set<PersistentDisk> disks = Sets.newLinkedHashSet();

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/PageWithMarker.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/PageWithMarker.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.domain;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Objects.equal;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.googlecomputeengine.domain.Resource.Kind;
+
+import java.beans.ConstructorProperties;
+import java.util.Iterator;
+
+import org.jclouds.collect.IterableWithMarker;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A single page returned from a paginated list call.
+ */
+public class PageWithMarker<T> extends IterableWithMarker<T> {
+
+   private final Kind kind;
+   private final String nextPageToken;
+   private final Iterable<T> items;
+
+   @ConstructorProperties({ "kind", "nextPageToken", "items" })
+   protected PageWithMarker(Kind kind, String nextPageToken, Iterable<T> items) {
+      this.kind = checkNotNull(kind, "kind");
+      this.nextPageToken = nextPageToken;
+      this.items = items != null ? ImmutableList.copyOf(items) : ImmutableList.<T>of();
+   }
+
+   public Kind getKind() {
+      return kind;
+   }
+
+   @Override
+   public Optional<Object> nextMarker() {
+      return Optional.<Object>fromNullable(nextPageToken);
+   }
+
+   @Override
+   public Iterator<T> iterator() {
+      return checkNotNull(items, "items").iterator();
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(kind, items);
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null || getClass() != obj.getClass())
+         return false;
+      PageWithMarker<?> that = PageWithMarker.class.cast(obj);
+      return equal(this.kind, that.kind) && equal(this.items, that.items);
+   }
+
+   protected MoreObjects.ToStringHelper string() {
+      return toStringHelper(this).omitNullValues().add("kind", kind).add("nextPageToken", nextPageToken)
+            .add("items", items);
+   }
+
+   @Override
+   public String toString() {
+      return string().toString();
+   }
+
+   public static <T> Builder<T> builder() {
+      return new Builder<T>();
+   }
+
+   public Builder<T> toBuilder() {
+      return new Builder<T>().fromPagedList(this);
+   }
+
+   public static final class Builder<T> {
+
+      private Kind kind;
+      private String nextPageToken;
+      private ImmutableList.Builder<T> items = ImmutableList.builder();
+
+      public Builder<T> kind(Kind kind) {
+         this.kind = kind;
+         return this;
+      }
+
+      public Builder<T> addItem(T item) {
+         this.items.add(item);
+         return this;
+      }
+
+      public Builder<T> items(Iterable<T> items) {
+         this.items.addAll(items);
+         return this;
+      }
+
+      public Builder<T> nextPageToken(String nextPageToken) {
+         this.nextPageToken = nextPageToken;
+         return this;
+      }
+
+      public PageWithMarker<T> build() {
+         return new PageWithMarker<T>(kind, nextPageToken, items.build());
+      }
+
+      public Builder<T> fromPagedList(PageWithMarker<T> in) {
+         return this
+                 .kind(in.getKind())
+                 .nextPageToken((String) in.nextMarker().orNull())
+                 .items(in);
+
+      }
+   }
+}

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/AddressApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/AddressApi.java
@@ -27,13 +27,12 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.Address;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
@@ -112,64 +111,18 @@ public interface AddressApi {
    Operation deleteInRegion(@PathParam("region") String region, @PathParam("address") String addressName);
 
    /**
-    * @see org.jclouds.googlecomputeengine.features.AddressApi#listAtMarkerInRegion(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Addresss:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/regions/{region}/addresses")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseAddresses.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Address> listFirstPageInRegion(@PathParam("region") String region);
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.AddressApi#listAtMarkerInRegion(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Addresss:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/regions/{region}/addresses")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseAddresses.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Address> listAtMarkerInRegion(@PathParam("region") String region, @QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the listPage of address resources contained within the specified project and region.
-    * By default the listPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has
-    * not been set.
-    *
-    * @param region        the region to search in
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the listPage
-    * @see org.jclouds.googlecomputeengine.options.ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Addresss:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/regions/{region}/addresses")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseAddresses.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Address> listAtMarkerInRegion(@PathParam("region") String region, @QueryParam("pageToken") @Nullable String marker, ListOptions listOptions);
-
-   /**
-    * A paged version of AddressApi#listPageInRegion(String)
+    * List all addresses in the given region.
     *
     * @param region the region to list in
     * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
     * @see org.jclouds.collect.PagedIterable
-    * @see org.jclouds.googlecomputeengine.features.AddressApi#listAtMarkerInRegion(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
     */
    @Named("Addresss:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/regions/{region}/addresses")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseAddresses.class)
+   @ResponseParser(ParseAddresses.ToPage.class)
    @Transform(ParseAddresses.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Address> listInRegion(@PathParam("region") String region);
@@ -180,8 +133,7 @@ public interface AddressApi {
    @Path("/regions/{region}/addresses")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseAddresses.class)
-   @Transform(ParseAddresses.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Address> listInRegion(@PathParam("region") String region, ListOptions options);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Address> listInRegion(@PathParam("region") String region, ListOptions options);
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/DiskApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/DiskApi.java
@@ -27,19 +27,18 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.Disk;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.functions.internal.ParseDisks;
-import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
 import org.jclouds.googlecomputeengine.handlers.DiskCreationBinder;
+import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
@@ -139,64 +138,18 @@ public interface DiskApi {
    Operation deleteInZone(@PathParam("zone") String zone, @PathParam("disk") String diskName);
 
    /**
-    * @see DiskApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Disks:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/zones/{zone}/disks")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseDisks.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Disk> listFirstPageInZone(@PathParam("zone") String zone);
-
-   /**
-    * @see DiskApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Disks:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/zones/{zone}/disks")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseDisks.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Disk> listAtMarkerInZone(@PathParam("zone") String zone, @QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the listPage of persistent disk resources contained within the specified project and zone.
-    * By default the listPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has
-    * not been set.
-    *
-    * @param zone        the zone to search in
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the listPage
-    * @see ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Disks:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/zones/{zone}/disks")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseDisks.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Disk> listAtMarkerInZone(@PathParam("zone") String zone, @QueryParam("pageToken") @Nullable String marker, ListOptions listOptions);
-
-   /**
-    * A paged version of DiskApi#listPageInZone(String)
+    * List all disks in the given zone.
     *
     * @param zone the zone to list in
     * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
     * @see PagedIterable
-    * @see DiskApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
     */
    @Named("Disks:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/zones/{zone}/disks")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseDisks.class)
+   @ResponseParser(ParseDisks.ToPage.class)
    @Transform(ParseDisks.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Disk> listInZone(@PathParam("zone") String zone);
@@ -207,9 +160,8 @@ public interface DiskApi {
    @Path("/zones/{zone}/disks")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseDisks.class)
-   @Transform(ParseDisks.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Disk> listInZone(@PathParam("zone") String zone, ListOptions options);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Disk> listInZone(@PathParam("zone") String zone, ListOptions options);
 
    /**
     * Create a snapshot of a given disk in a zone.

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/DiskTypeApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/DiskTypeApi.java
@@ -23,10 +23,8 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
@@ -34,7 +32,6 @@ import org.jclouds.googlecomputeengine.domain.DiskType;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.functions.internal.ParseDiskTypes;
 import org.jclouds.googlecomputeengine.options.ListOptions;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
 import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
 import org.jclouds.rest.annotations.Fallback;
@@ -68,75 +65,23 @@ public interface DiskTypeApi {
       DiskType getInZone(@PathParam("zone") String zone, @PathParam("diskType") String diskTypeName);
 
       /**
-       * @see DiskTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
+       * List all disk types int he given zone.
        */
       @Named("DiskTypes:list")
       @GET
       @Path("/zones/{zone}/diskTypes")
       @OAuthScopes(COMPUTE_READONLY_SCOPE)
-      @ResponseParser(ParseDiskTypes.class)
-      @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-      ListPage<DiskType> listFirstPageInZone(@PathParam("zone") String zone);
-
-      /**
-       * @see DiskTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-       */
-      @Named("DiskTypes:list")
-      @GET
-      @Path("/zones/{zone}/diskType")
-      @OAuthScopes(COMPUTE_READONLY_SCOPE)
-      @ResponseParser(ParseDiskTypes.class)
-      @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-      ListPage<DiskType> listAtMarkerInZone(@PathParam("zone") String zone, @QueryParam("pageToken") @Nullable String marker);
-
-      /**
-       * Retrieves the list of disk type resources available to the specified project.
-       * By default the list as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has not
-       * been set.
-       *
-       * @param zone        The name of the zone to list in.
-       * @param marker      marks the beginning of the next list page
-       * @param listOptions listing options
-       * @return a page of the list
-       * @see ListOptions
-       * @see org.jclouds.googlecomputeengine.domain.ListPage
-       */
-      @Named("DiskTypes:list")
-      @GET
-      @Path("/zones/{zone}/diskTypes")
-      @OAuthScopes(COMPUTE_READONLY_SCOPE)
-      @ResponseParser(ParseDiskTypes.class)
-      @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-      ListPage<DiskType> listAtMarkerInZone(@PathParam("zone") String zone,
-                                            @QueryParam("pageToken") @Nullable String marker,
-                                            ListOptions listOptions);
-
-      /**
-       * @see DiskTypeApi#listInZone(String, org.jclouds.googlecomputeengine.options.ListOptions)
-       */
-      @Named("DiskTypes:list")
-      @GET
-      @Path("/zones/{zone}/diskTypes")
-      @OAuthScopes(COMPUTE_READONLY_SCOPE)
-      @ResponseParser(ParseDiskTypes.class)
+      @ResponseParser(ParseDiskTypes.ToPage.class)
       @Transform(ParseDiskTypes.ToPagedIterable.class)
       @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
       PagedIterable<DiskType> listInZone(@PathParam("zone") String zone);
 
-      /**
-       * @see DiskTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-       *
-       * @param zone the zone to list in
-       * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-       * @see PagedIterable
-       */
       @Named("DiskTypes:list")
       @GET
       @Path("/zones/{zone}/diskTypes")
       @OAuthScopes(COMPUTE_READONLY_SCOPE)
       @ResponseParser(ParseDiskTypes.class)
-      @Transform(ParseDiskTypes.ToPagedIterable.class)
       @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-      PagedIterable<DiskType> listInZone(@PathParam("zone") String zone, ListOptions listOptions);
+      ListPage<DiskType> listInZone(@PathParam("zone") String zone, ListOptions listOptions);
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/FirewallApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/FirewallApi.java
@@ -30,17 +30,15 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.Firewall;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
-import org.jclouds.googlecomputeengine.functions.internal.PATCH;
 import org.jclouds.googlecomputeengine.functions.internal.ParseFirewalls;
 import org.jclouds.googlecomputeengine.handlers.FirewallBinder;
 import org.jclouds.googlecomputeengine.options.FirewallOptions;
@@ -51,6 +49,7 @@ import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.MapBinder;
+import org.jclouds.rest.annotations.PATCH;
 import org.jclouds.rest.annotations.PayloadParam;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
@@ -152,76 +151,24 @@ public interface FirewallApi {
    Operation delete(@PathParam("firewall") String firewallName);
 
    /**
-    * @see FirewallApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all firewalls.
     */
    @Named("Firewalls:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/global/firewalls")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseFirewalls.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Firewall> listFirstPage();
-
-   /**
-    * @see FirewallApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Firewalls:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/firewalls")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseFirewalls.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Firewall> listAtMarker(@QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the list of firewall resources available to the specified project.
-    * By default the list as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has not
-    * been set.
-    *
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the list
-    * @see ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Firewalls:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/firewalls")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseFirewalls.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Firewall> listAtMarker(@QueryParam("pageToken") @Nullable String marker, ListOptions options);
-
-   /**
-    * @see FirewallApi#list(org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Firewalls:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/firewalls")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseFirewalls.class)
+   @ResponseParser(ParseFirewalls.ToPage.class)
    @Transform(ParseFirewalls.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Firewall> list();
 
-   /**
-    * A paged version of FirewallApi#list()
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see PagedIterable
-    * @see FirewallApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
    @Named("Firewalls:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/global/firewalls")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseFirewalls.class)
-   @Transform(ParseFirewalls.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Firewall> list(ListOptions options);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Firewall> list(ListOptions options);
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/GlobalOperationApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/GlobalOperationApi.java
@@ -25,18 +25,16 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.functions.internal.ParseGlobalOperations;
 import org.jclouds.googlecomputeengine.options.ListOptions;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
 import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
 import org.jclouds.rest.annotations.Fallback;
@@ -81,78 +79,25 @@ public interface GlobalOperationApi {
    void delete(@PathParam("operation") String operationName);
 
    /**
-    * @see org.jclouds.googlecomputeengine.features.GlobalOperationApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all global operations.
     */
    @Named("GlobalOperations:list")
    @GET
    @Path("/global/operations")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseGlobalOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listFirstPage();
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.GlobalOperationApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("GlobalOperations:list")
-   @GET
-   @Path("/global/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseGlobalOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listAtMarker(@QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the listFirstPage of operation resources contained within the specified project.
-    * By default the listFirstPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults()
-    * has not been set.
-    *
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the list, starting at marker
-    * @see org.jclouds.googlecomputeengine.options.ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("GlobalOperations:list")
-   @GET
-   @Path("/global/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseGlobalOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listAtMarker(@QueryParam("pageToken") @Nullable String marker,
-                                    ListOptions listOptions);
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.GlobalOperationApi#list(org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("GlobalOperations:list")
-   @GET
-   @Path("/global/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseGlobalOperations.class)
+   @ResponseParser(ParseGlobalOperations.ToPage.class)
    @Transform(ParseGlobalOperations.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Operation> list();
 
-   /**
-    * A paged version of GlobalOperationApi#listFirstPage()
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see org.jclouds.collect.PagedIterable
-    * @see org.jclouds.googlecomputeengine.features.GlobalOperationApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
    @Named("GlobalOperations:list")
    @GET
    @Path("/global/operations")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @Consumes(MediaType.APPLICATION_JSON)
    @ResponseParser(ParseGlobalOperations.class)
-   @Transform(ParseGlobalOperations.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Operation> list(ListOptions listOptions);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Operation> list(ListOptions listOptions);
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ImageApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ImageApi.java
@@ -27,13 +27,12 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.Image;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
@@ -92,82 +91,29 @@ public interface ImageApi {
    Operation delete(@PathParam("image") String imageName);
 
    /**
-    * @see ImageApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Images:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/images")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseImages.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Image> listFirstPage();
-
-   /**
-    * @see ImageApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Images:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/images")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseImages.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Image> listAtMarker(@QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the list of image resources available to the specified project.
-    * By default the list as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has not
-    * been set.
-    *
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the list
-    * @see ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Images:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/images")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseImages.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Image> listAtMarker(@QueryParam("pageToken") @Nullable String marker, ListOptions listOptions);
-
-   /**
-    * A paged version of ImageApi#list()
+    * List all images
     *
     * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
     * @see PagedIterable
-    * @see ImageApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
     */
    @Named("Images:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/global/images")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseImages.class)
+   @ResponseParser(ParseImages.ToPage.class)
    @Transform(ParseImages.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Image> list();
 
-   /**
-    * A paged version of ImageApi#list()
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see PagedIterable
-    * @see ImageApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
    @Named("Images:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/global/images")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseImages.class)
-   @Transform(ParseImages.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Image> list(ListOptions options);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Image> list(ListOptions options);
 
    /**
     * Creates an image resource in the specified project from the provided persistent disk.

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/InstanceApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/InstanceApi.java
@@ -33,10 +33,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.Instance;
 import org.jclouds.googlecomputeengine.domain.InstanceTemplate;
 import org.jclouds.googlecomputeengine.domain.ListPage;
@@ -105,7 +105,6 @@ public interface InstanceApi {
    Operation createInZone(@PayloadParam("name") String instanceName, @PathParam("zone") String zone,
                           @PayloadParam("template") InstanceTemplate template);
                           
-
    /**
     * Deletes the specified instance resource.
     *
@@ -124,82 +123,26 @@ public interface InstanceApi {
    Operation deleteInZone(@PathParam("zone") String zone, @PathParam("instance") String instanceName);
 
    /**
-    * A paged version of InstanceApi#listInZone()
-    *
-    * @param zone zone instances are in
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see PagedIterable
-    * @see InstanceApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all instances in the given zone.
     */
    @Named("Instances:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/zones/{zone}/instances")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseInstances.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Instance> listFirstPageInZone(@PathParam("zone") String zone);
-
-   /**
-    * Retrieves the list of instance resources available to the specified project.
-    * By default the list as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has not
-    * been set.
-    *
-    * @param zone zone instances are in
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the list
-    * @see ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Instances:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/zones/{zone}/instances")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseInstances.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Instance> listAtMarkerInZone(@PathParam("zone") String zone, @Nullable String marker,
-                                         ListOptions listOptions);
-
-   /**
-    * @see InstanceApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Instances:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/zones/{zone}/instances")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseInstances.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Instance> listAtMarkerInZone(@PathParam("zone") String zone,
-                                         @Nullable String marker);
-
-   /**
-    * @see InstanceApi#listInZone(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Instances:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/zones/{zone}/instances")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseInstances.class)
+   @ResponseParser(ParseInstances.ToPage.class)
    @Transform(ParseInstances.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Instance> listInZone(@PathParam("zone") String zone);
 
-   /**
-    * @see InstanceApi#listInZone(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
    @Named("Instances:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/zones/{zone}/instances")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseInstances.class)
-   @Transform(ParseInstances.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Instance> listInZone(@PathParam("zone") String zone, ListOptions options);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Instance> listInZone(@PathParam("zone") String zone, ListOptions options);
 
    /**
     * Adds an access config to an instance's network interface.

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/MachineTypeApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/MachineTypeApi.java
@@ -23,18 +23,16 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.MachineType;
 import org.jclouds.googlecomputeengine.functions.internal.ParseMachineTypes;
 import org.jclouds.googlecomputeengine.options.ListOptions;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
 import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
 import org.jclouds.rest.annotations.Fallback;
@@ -68,76 +66,23 @@ public interface MachineTypeApi {
    MachineType getInZone(@PathParam("zone") String zone, @PathParam("machineType") String machineTypeName);
 
    /**
-    * @see MachineTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all machine types in the given zone.
     */
    @Named("MachineTypes:list")
    @GET
    @Path("/zones/{zone}/machineTypes")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseMachineTypes.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<MachineType> listFirstPageInZone(@PathParam("zone") String zone);
-
-   /**
-    * @see MachineTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("MachineTypes:list")
-   @GET
-   @Path("/zones/{zone}/machineTypes")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseMachineTypes.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<MachineType> listAtMarkerInZone(@PathParam("zone") String zone, @QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the list of machine type resources available to the specified project.
-    * By default the list as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has not
-    * been set.
-    *
-    * @param zone        The name of the zone to list in.
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the list
-    * @see ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("MachineTypes:list")
-   @GET
-   @Path("/zones/{zone}/machineTypes")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseMachineTypes.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<MachineType> listAtMarkerInZone(@PathParam("zone") String zone,
-                                            @QueryParam("pageToken") @Nullable String marker,
-                                            ListOptions listOptions);
-
-   /**
-    * @see MachineTypeApi#listInZone(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("MachineTypes:list")
-   @GET
-   @Path("/zones/{zone}/machineTypes")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseMachineTypes.class)
+   @ResponseParser(ParseMachineTypes.ToPage.class)
    @Transform(ParseMachineTypes.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<MachineType> listInZone(@PathParam("zone") String zone);
 
-   /**
-    * A paged version of MachineTypeApi#listInZone(String)
-    *
-    * @param zone the zone to list in
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see PagedIterable
-    * @see MachineTypeApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
    @Named("MachineTypes:list")
    @GET
    @Path("/zones/{zone}/machineTypes")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseMachineTypes.class)
-   @Transform(ParseMachineTypes.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<MachineType> listInZone(@PathParam("zone") String zone, ListOptions listOptions);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<MachineType> listInZone(@PathParam("zone") String zone, ListOptions listOptions);
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/NetworkApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/NetworkApi.java
@@ -27,19 +27,17 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Network;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.functions.internal.ParseNetworks;
 import org.jclouds.googlecomputeengine.options.ListOptions;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
 import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
 import org.jclouds.rest.annotations.Fallback;
@@ -128,77 +126,24 @@ public interface NetworkApi {
    Operation delete(@PathParam("network") String networkName);
 
    /**
-    * @see NetworkApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all networks.
     */
    @Named("Networks:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/global/networks")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseNetworks.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Network> listFirstPage();
-
-   /**
-    * @see NetworkApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Networks:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/networks")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseNetworks.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Network> listAtMarker(@QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the list of persistent network resources contained within the specified project.
-    * By default the list as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has not
-    * been set.
-    *
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the list
-    * @see ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Networks:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/networks")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseNetworks.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Network> listAtMarker(@QueryParam("pageToken") @Nullable String marker,
-                                  ListOptions options);
-
-   /**
-    * @see NetworkApi#list(org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Networks:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/networks")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseNetworks.class)
+   @ResponseParser(ParseNetworks.ToPage.class)
    @Transform(ParseNetworks.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Network> list();
 
-   /**
-    * A paged version of NetworkApi#list()
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see PagedIterable
-    * @see NetworkApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
    @Named("Networks:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/global/networks")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseNetworks.class)
-   @Transform(ParseNetworks.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Network> list(ListOptions options);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Network> list(ListOptions options);
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/RegionApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/RegionApi.java
@@ -25,10 +25,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Region;
 import org.jclouds.googlecomputeengine.functions.internal.ParseRegions;
@@ -65,71 +65,22 @@ public interface RegionApi {
    Region get(@PathParam("region") String regionName);
 
    /**
-    * @see org.jclouds.googlecomputeengine.features.RegionApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all regions.
     */
    @Named("Regions:list")
    @GET
    @Path("/regions")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseRegions.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Region> listFirstPage();
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.RegionApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Regions:list")
-   @GET
-   @Path("/regions")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseRegions.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Region> listAtMarker(String marker);
-
-   /**
-    * Retrieves the listFirstPage of region resources available to the specified project.
-    * By default the listFirstPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults()
-    * has not been set.
-    *
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the listFirstPage
-    * @see org.jclouds.googlecomputeengine.options.ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Regions:list")
-   @GET
-   @Path("/regions")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseRegions.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Region> listAtMarker(String marker, ListOptions listOptions);
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.RegionApi#list(org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Regions:list")
-   @GET
-   @Path("/regions")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseRegions.class)
+   @ResponseParser(ParseRegions.ToPage.class)
    @Transform(ParseRegions.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Region> list();
 
-   /**
-    * A paged version of RegionApi#listFirstPage()
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see org.jclouds.googlecomputeengine.features.RegionApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    * @see org.jclouds.collect.PagedIterable
-    */
    @Named("Regions:list")
    @GET
    @Path("/regions")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseRegions.class)
-   @Transform(ParseRegions.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Region> list(ListOptions listOptions);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Region> list(ListOptions listOptions);
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/RegionOperationApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/RegionOperationApi.java
@@ -25,18 +25,16 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.functions.internal.ParseRegionOperations;
 import org.jclouds.googlecomputeengine.options.ListOptions;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
 import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
 import org.jclouds.rest.annotations.Fallback;
@@ -83,81 +81,25 @@ public interface RegionOperationApi {
    void deleteInRegion(@PathParam("region") String region, @PathParam("operation") String operationName);
 
    /**
-    * @see org.jclouds.googlecomputeengine.features.RegionOperationApi#listAtMarkerInRegion(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all region operations in the given region.
     */
    @Named("RegionOperations:list")
    @GET
    @Path("/regions/{region}/operations")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseRegionOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listFirstPageInRegion(@PathParam("region") String region);
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.RegionOperationApi#listAtMarkerInRegion(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("RegionOperations:list")
-   @GET
-   @Path("/regions/{region}/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseRegionOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listAtMarkerInRegion(@PathParam("region") String region,
-                                            @QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the listFirstPage of operation resources contained within the specified project.
-    * By default the listFirstPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults()
-    * has not been set.
-    *
-    * @param region      the region to list in
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the list, starting at marker
-    * @see org.jclouds.googlecomputeengine.options.ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("RegionOperations:list")
-   @GET
-   @Path("/regions/{region}/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseRegionOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listAtMarkerInRegion(@PathParam("region") String region,
-                                            @QueryParam("pageToken") @Nullable String marker,
-                                            ListOptions listOptions);
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.RegionOperationApi#listInRegion(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("RegionOperations:list")
-   @GET
-   @Path("/regions/{region}/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseRegionOperations.class)
+   @ResponseParser(ParseRegionOperations.ToPage.class)
    @Transform(ParseRegionOperations.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Operation> listInRegion(@PathParam("region") String region);
 
-   /**
-    * A paged version of RegionOperationApi#listFirstPageInRegion(String)
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see org.jclouds.collect.PagedIterable
-    * @see org.jclouds.googlecomputeengine.features.RegionOperationApi#listAtMarkerInRegion(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
    @Named("RegionOperations:list")
    @GET
    @Path("/regions/{region}/operations")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @Consumes(MediaType.APPLICATION_JSON)
    @ResponseParser(ParseRegionOperations.class)
-   @Transform(ParseRegionOperations.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Operation> listInRegion(@PathParam("region") String region, ListOptions listOptions);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Operation> listInRegion(@PathParam("region") String region, ListOptions listOptions);
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/RouteApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/RouteApi.java
@@ -31,10 +31,10 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.domain.Route;
@@ -77,73 +77,24 @@ public interface RouteApi {
    Route get(@PathParam("route") String routeName);
 
    /**
-    * @see org.jclouds.googlecomputeengine.features.RouteApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all routers.
     */
    @Named("Routes:list")
    @GET
    @Path("/global/routes")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseRoutes.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Route> listFirstPage();
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.RouteApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Routes:list")
-   @GET
-   @Path("/global/routes")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseRoutes.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Route> listAtMarker(String marker);
-
-   /**
-    * Retrieves the listFirstPage of route resources available to the specified project.
-    * By default the listFirstPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults()
-    * has not been set.
-    *
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the listFirstPage
-    * @see org.jclouds.googlecomputeengine.options.ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Routes:list")
-   @GET
-   @Path("/global/routes")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseRoutes.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Route> listAtMarker(String marker, ListOptions listOptions);
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.RouteApi#list(org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Routes:list")
-   @GET
-   @Path("/global/routes")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseRoutes.class)
+   @ResponseParser(ParseRoutes.ToPage.class)
    @Transform(ParseRoutes.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Route> list();
 
-   /**
-    * A paged version of RegionApi#listFirstPage()
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see org.jclouds.googlecomputeengine.features.RouteApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    * @see org.jclouds.collect.PagedIterable
-    */
    @Named("Routes:list")
    @GET
    @Path("/global/routes")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseRoutes.class)
-   @Transform(ParseRoutes.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Route> list(ListOptions listOptions);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Route> list(ListOptions listOptions);
 
    /**
     * Deletes the specified route resource.

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/SnapshotApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/SnapshotApi.java
@@ -25,13 +25,12 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.domain.Snapshot;
@@ -87,62 +86,17 @@ public interface SnapshotApi {
    Operation delete(@PathParam("snapshot") String snapshotName);
 
    /**
-    * @see org.jclouds.googlecomputeengine.features.SnapshotApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Snapshots:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/snapshots")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseSnapshots.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Snapshot> listFirstPage();
-
-   /**
-    * @see org.jclouds.googlecomputeengine.features.SnapshotApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Snapshots:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/snapshots")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseSnapshots.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Snapshot> listAtMarker(@QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the listPage of persistent disk resources contained within the specified project and zone.
-    * By default the listPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults() has
-    * not been set.
-    *
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the listPage
-    * @see org.jclouds.googlecomputeengine.options.ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("Snapshots:list")
-   @GET
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/global/snapshots")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseSnapshots.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Snapshot> listAtMarker(@QueryParam("pageToken") @Nullable String marker, ListOptions listOptions);
-
-   /**
-    * A paged version of SnapshotApi#listPage(String)
+    * List all snapshots.
     *
     * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
     * @see org.jclouds.collect.PagedIterable
-    * @see org.jclouds.googlecomputeengine.features.SnapshotApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
     */
    @Named("Snapshots:list")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/global/snapshots")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseSnapshots.class)
+   @ResponseParser(ParseSnapshots.ToPage.class)
    @Transform(ParseSnapshots.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Snapshot> list();
@@ -153,8 +107,7 @@ public interface SnapshotApi {
    @Path("/global/snapshots")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseSnapshots.class)
-   @Transform(ParseSnapshots.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Snapshot> list(ListOptions options);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Snapshot> list(ListOptions options);
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ZoneApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ZoneApi.java
@@ -25,10 +25,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Zone;
 import org.jclouds.googlecomputeengine.functions.internal.ParseZones;
@@ -65,71 +65,22 @@ public interface ZoneApi {
    Zone get(@PathParam("zone") String zoneName);
 
    /**
-    * @see ZoneApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all zones.
     */
    @Named("Zones:list")
    @GET
    @Path("/zones")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseZones.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Zone> listFirstPage();
-
-   /**
-    * @see ZoneApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Zones:list")
-   @GET
-   @Path("/zones")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseZones.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Zone> listAtMarker(String marker);
-
-   /**
-    * Retrieves the listFirstPage of zone resources available to the specified project.
-    * By default the listFirstPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults()
-    * has not been set.
-    *
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the listFirstPage
-    * @see ListOptions
-    * @see ListPage
-    */
-   @Named("Zones:list")
-   @GET
-   @Path("/zones")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseZones.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Zone> listAtMarker(String marker, ListOptions listOptions);
-
-   /**
-    * @see ZoneApi#list(org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("Zones:list")
-   @GET
-   @Path("/zones")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @ResponseParser(ParseZones.class)
+   @ResponseParser(ParseZones.ToPage.class)
    @Transform(ParseZones.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Zone> list();
 
-   /**
-    * A paged version of ZoneApi#listFirstPage()
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see ZoneApi#listAtMarker(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    * @see PagedIterable
-    */
    @Named("Zones:list")
    @GET
    @Path("/zones")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @ResponseParser(ParseZones.class)
-   @Transform(ParseZones.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Zone> list(ListOptions listOptions);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Zone> list(ListOptions listOptions);
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ZoneOperationApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ZoneOperationApi.java
@@ -25,18 +25,16 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404;
 import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineFallbacks.EmptyListPageOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.functions.internal.ParseZoneOperations;
 import org.jclouds.googlecomputeengine.options.ListOptions;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.oauth.v2.config.OAuthScopes;
 import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
 import org.jclouds.rest.annotations.Fallback;
@@ -83,81 +81,25 @@ public interface ZoneOperationApi {
    void deleteInZone(@PathParam("zone") String zone, @PathParam("operation") String operationName);
 
    /**
-    * @see ZoneOperationApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
+    * List all zone operations int he given zone.
     */
    @Named("ZoneOperations:list")
    @GET
    @Path("/zones/{zone}/operations")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseZoneOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listFirstPageInZone(@PathParam("zone") String zone);
-
-   /**
-    * @see ZoneOperationApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("ZoneOperations:list")
-   @GET
-   @Path("/zones/{zone}/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseZoneOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listAtMarkerInZone(@PathParam("zone") String zone,
-                                          @QueryParam("pageToken") @Nullable String marker);
-
-   /**
-    * Retrieves the listFirstPage of operation resources contained within the specified project.
-    * By default the listFirstPage as a maximum size of 100, if no options are provided or ListOptions#getMaxResults()
-    * has not been set.
-    *
-    * @param zone        the zone to list in
-    * @param marker      marks the beginning of the next list page
-    * @param listOptions listing options
-    * @return a page of the list, starting at marker
-    * @see ListOptions
-    * @see org.jclouds.googlecomputeengine.domain.ListPage
-    */
-   @Named("ZoneOperations:list")
-   @GET
-   @Path("/zones/{zone}/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseZoneOperations.class)
-   @Fallback(EmptyIterableWithMarkerOnNotFoundOr404.class)
-   ListPage<Operation> listAtMarkerInZone(@PathParam("zone") String zone,
-                                          @QueryParam("pageToken") @Nullable String marker,
-                                          ListOptions listOptions);
-
-   /**
-    * @see ZoneOperationApi#listInZone(String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
-   @Named("ZoneOperations:list")
-   @GET
-   @Path("/zones/{zone}/operations")
-   @OAuthScopes(COMPUTE_READONLY_SCOPE)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @ResponseParser(ParseZoneOperations.class)
+   @ResponseParser(ParseZoneOperations.ToPage.class)
    @Transform(ParseZoneOperations.ToPagedIterable.class)
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Operation> listInZone(@PathParam("zone") String zone);
 
-   /**
-    * A paged version of ZoneOperationApi#listFirstPageInZone(String)
-    *
-    * @return a Paged, Fluent Iterable that is able to fetch additional pages when required
-    * @see PagedIterable
-    * @see ZoneOperationApi#listAtMarkerInZone(String, String, org.jclouds.googlecomputeengine.options.ListOptions)
-    */
    @Named("ZoneOperations:list")
    @GET
    @Path("/zones/{zone}/operations")
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @Consumes(MediaType.APPLICATION_JSON)
    @ResponseParser(ParseZoneOperations.class)
-   @Transform(ParseZoneOperations.ToPagedIterable.class)
-   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
-   PagedIterable<Operation> listInZone(@PathParam("zone") String zone, ListOptions listOptions);
+   @Fallback(EmptyListPageOnNotFoundOr404.class)
+   ListPage<Operation> listInZone(@PathParam("zone") String zone, ListOptions listOptions);
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/BasePageParser.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/BasePageParser.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.functions.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.collect.PagedIterable;
+import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.http.functions.ParseJson;
+import org.jclouds.rest.InvocationContext;
+
+import com.google.common.base.Function;
+
+/**
+ * Base class for the classes that parse a single page resulting of a call to a
+ * paginated api.
+ */
+public abstract class BasePageParser<T, I extends BasePageParser<T, I>> implements Function<HttpResponse, ListPage<T>>, InvocationContext<I> {
+
+   protected final ParseJson<PageWithMarker<T>> parser;
+   protected final Function<PageWithMarker<T>, PagedIterable<T>> advancingFunction;
+
+   protected BasePageParser(ParseJson<PageWithMarker<T>> parser,
+         Function<PageWithMarker<T>, PagedIterable<T>> advancingFunction) {
+      this.parser = checkNotNull(parser, "parser");
+      this.advancingFunction = checkNotNull(advancingFunction, "advancingFunction");
+
+   }
+
+   @Override
+   public ListPage<T> apply(HttpResponse from) {
+      PageWithMarker<T> page = parser.apply(from);
+      return new ListPage<T>(page, advancingFunction);
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public I setContext(HttpRequest request) {
+      if (advancingFunction instanceof InvocationContext) {
+         InvocationContext.class.cast(advancingFunction).setContext(request);
+      }
+      return (I) this;
+   }
+}

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/BaseToPagedIterable.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/BaseToPagedIterable.java
@@ -22,7 +22,7 @@ import static com.google.common.collect.Iterables.tryFind;
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.collect.PagedIterables;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.rest.InvocationContext;
@@ -34,14 +34,14 @@ import com.google.common.base.Optional;
 
 @Beta
 public abstract class BaseToPagedIterable<T, I extends BaseToPagedIterable<T, I>> implements
-        Function<ListPage<T>, PagedIterable<T>>, InvocationContext<I> {
+        Function<PageWithMarker<T>, PagedIterable<T>>, InvocationContext<I> {
 
    private GeneratedHttpRequest request;
 
    @Override
-   public PagedIterable<T> apply(ListPage<T> input) {
+   public PagedIterable<T> apply(PageWithMarker<T> input) {
       if (input.nextMarker() == null)
-         return PagedIterables.of(input);
+         return PagedIterables.onlyPage(input);
 
       Optional<Object> project = tryFind(request.getCaller().get().getArgs(), instanceOf(String.class));
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/BaseWithRegionToPagedIterable.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/BaseWithRegionToPagedIterable.java
@@ -22,7 +22,7 @@ import static com.google.common.collect.Iterables.tryFind;
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.collect.PagedIterables;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.rest.InvocationContext;
@@ -34,14 +34,14 @@ import com.google.common.base.Optional;
 
 @Beta
 public abstract class BaseWithRegionToPagedIterable<T, I extends BaseWithRegionToPagedIterable<T, I>> implements
-        Function<ListPage<T>, PagedIterable<T>>, InvocationContext<I> {
+        Function<PageWithMarker<T>, PagedIterable<T>>, InvocationContext<I> {
 
    private GeneratedHttpRequest request;
 
    @Override
-   public PagedIterable<T> apply(ListPage<T> input) {
+   public PagedIterable<T> apply(PageWithMarker<T> input) {
       if (input.nextMarker() == null)
-         return PagedIterables.of(input);
+         return PagedIterables.onlyPage(input);
 
       Optional <Object> project = tryFind(request.getCaller().get().getArgs(), instanceOf(String.class));
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/BaseWithZoneToPagedIterable.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/BaseWithZoneToPagedIterable.java
@@ -22,7 +22,7 @@ import static com.google.common.collect.Iterables.tryFind;
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.collect.PagedIterables;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.rest.InvocationContext;
@@ -34,14 +34,14 @@ import com.google.common.base.Optional;
 
 @Beta
 public abstract class BaseWithZoneToPagedIterable<T, I extends BaseWithZoneToPagedIterable<T, I>> implements
-        Function<ListPage<T>, PagedIterable<T>>, InvocationContext<I> {
+        Function<PageWithMarker<T>, PagedIterable<T>>, InvocationContext<I> {
 
    private GeneratedHttpRequest request;
 
    @Override
-   public PagedIterable<T> apply(ListPage<T> input) {
+   public PagedIterable<T> apply(PageWithMarker<T> input) {
       if (input.nextMarker() == null)
-         return PagedIterables.of(input);
+         return PagedIterables.onlyPage(input);
 
       Optional<Object> project = tryFind(request.getCaller().get().getArgs(), instanceOf(String.class));
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/ParseDisks.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/ParseDisks.java
@@ -24,7 +24,7 @@ import javax.inject.Singleton;
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
 import org.jclouds.googlecomputeengine.domain.Disk;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.jclouds.http.functions.ParseJson;
 import org.jclouds.json.Json;
@@ -33,12 +33,19 @@ import com.google.common.base.Function;
 import com.google.inject.TypeLiteral;
 
 @Singleton
-public class ParseDisks extends ParseJson<ListPage<Disk>> {
+public class ParseDisks extends BasePageParser<Disk, ParseDisks> {
 
    @Inject
-   public ParseDisks(Json json) {
-      super(json, new TypeLiteral<ListPage<Disk>>() {
-      });
+   ParseDisks(ToPage toPage, ToPagedIterable toPagedIterable) {
+      super(toPage, toPagedIterable);
+   }
+   
+   public static class ToPage extends ParseJson<PageWithMarker<Disk>> {
+      @Inject
+      ToPage(Json json, TypeLiteral<PageWithMarker<Disk>> type) {
+         super(json, new TypeLiteral<PageWithMarker<Disk>>() {
+         });
+      }
    }
 
    public static class ToPagedIterable extends BaseWithZoneToPagedIterable<Disk, ToPagedIterable> {
@@ -46,20 +53,19 @@ public class ParseDisks extends ParseJson<ListPage<Disk>> {
       private final GoogleComputeEngineApi api;
 
       @Inject
-      protected ToPagedIterable(GoogleComputeEngineApi api) {
+      ToPagedIterable(GoogleComputeEngineApi api) {
          this.api = checkNotNull(api, "api");
       }
 
       @Override
       protected Function<Object, IterableWithMarker<Disk>> fetchNextPage(final String projectName,
-                                                                         final String zoneName,
-                                                                         final ListOptions options) {
+            final String zoneName, final ListOptions options) {
          return new Function<Object, IterableWithMarker<Disk>>() {
 
             @Override
             public IterableWithMarker<Disk> apply(Object input) {
-               return api.getDiskApiForProject(projectName)
-                       .listAtMarkerInZone(zoneName, input.toString(), options);
+               options.pageToken(input.toString());
+               return api.getDiskApiForProject(projectName).listInZone(zoneName, options);
             }
          };
       }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/ParseRegionOperations.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/ParseRegionOperations.java
@@ -22,8 +22,8 @@ import javax.inject.Inject;
 
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
-import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.jclouds.http.functions.ParseJson;
 import org.jclouds.json.Json;
@@ -31,12 +31,19 @@ import org.jclouds.json.Json;
 import com.google.common.base.Function;
 import com.google.inject.TypeLiteral;
 
-public class ParseRegionOperations extends ParseJson<ListPage<Operation>> {
+public class ParseRegionOperations extends BasePageParser<Operation, ParseRegionOperations> {
 
    @Inject
-   public ParseRegionOperations(Json json) {
-      super(json, new TypeLiteral<ListPage<Operation>>() {
-      });
+   ParseRegionOperations(ToPage toPage, ToPagedIterable toPagedIterable) {
+      super(toPage, toPagedIterable);
+   }
+
+   public static class ToPage extends ParseJson<PageWithMarker<Operation>> {
+      @Inject
+      ToPage(Json json, TypeLiteral<PageWithMarker<Operation>> type) {
+         super(json, new TypeLiteral<PageWithMarker<Operation>>() {
+         });
+      }
    }
 
    public static class ToPagedIterable extends BaseWithRegionToPagedIterable<Operation, ToPagedIterable> {
@@ -44,20 +51,19 @@ public class ParseRegionOperations extends ParseJson<ListPage<Operation>> {
       private final GoogleComputeEngineApi api;
 
       @Inject
-      protected ToPagedIterable(GoogleComputeEngineApi api) {
+      ToPagedIterable(GoogleComputeEngineApi api) {
          this.api = checkNotNull(api, "api");
       }
 
       @Override
       protected Function<Object, IterableWithMarker<Operation>> fetchNextPage(final String projectName,
-                                                                              final String regionName,
-                                                                              final ListOptions options) {
+            final String regionName, final ListOptions options) {
          return new Function<Object, IterableWithMarker<Operation>>() {
 
             @Override
             public IterableWithMarker<Operation> apply(Object input) {
-               return api.getRegionOperationApiForProject(projectName)
-                       .listAtMarkerInRegion(regionName, input.toString(), options);
+               options.pageToken(input.toString());
+               return api.getRegionOperationApiForProject(projectName).listInRegion(regionName, options);
             }
          };
       }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/ParseZoneOperations.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/functions/internal/ParseZoneOperations.java
@@ -22,8 +22,8 @@ import javax.inject.Inject;
 
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
-import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.jclouds.http.functions.ParseJson;
 import org.jclouds.json.Json;
@@ -31,12 +31,19 @@ import org.jclouds.json.Json;
 import com.google.common.base.Function;
 import com.google.inject.TypeLiteral;
 
-public class ParseZoneOperations extends ParseJson<ListPage<Operation>> {
+public class ParseZoneOperations extends BasePageParser<Operation, ParseZoneOperations> {
 
    @Inject
-   public ParseZoneOperations(Json json) {
-      super(json, new TypeLiteral<ListPage<Operation>>() {
-      });
+   ParseZoneOperations(ToPage toPage, ToPagedIterable toPagedIterable) {
+      super(toPage, toPagedIterable);
+   }
+
+   public static class ToPage extends ParseJson<PageWithMarker<Operation>> {
+      @Inject
+      ToPage(Json json, TypeLiteral<PageWithMarker<Operation>> type) {
+         super(json, new TypeLiteral<PageWithMarker<Operation>>() {
+         });
+      }
    }
 
    public static class ToPagedIterable extends BaseWithZoneToPagedIterable<Operation, ToPagedIterable> {
@@ -44,20 +51,19 @@ public class ParseZoneOperations extends ParseJson<ListPage<Operation>> {
       private final GoogleComputeEngineApi api;
 
       @Inject
-      protected ToPagedIterable(GoogleComputeEngineApi api) {
+      ToPagedIterable(GoogleComputeEngineApi api) {
          this.api = checkNotNull(api, "api");
       }
 
       @Override
       protected Function<Object, IterableWithMarker<Operation>> fetchNextPage(final String projectName,
-                                                                              final String zoneName,
-                                                                              final ListOptions options) {
+            final String zoneName, final ListOptions options) {
          return new Function<Object, IterableWithMarker<Operation>>() {
 
             @Override
             public IterableWithMarker<Operation> apply(Object input) {
-               return api.getZoneOperationApiForProject(projectName)
-                       .listAtMarkerInZone(zoneName, input.toString(), options);
+               options.pageToken(input.toString());
+               return api.getZoneOperationApiForProject(projectName).listInZone(zoneName, options);
             }
          };
       }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/ListOptions.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/ListOptions.java
@@ -72,6 +72,16 @@ public class ListOptions extends BaseHttpRequestOptions {
       return this;
    }
 
+   /**
+    * Sets the marker to the page to retrieve.
+    */
+   public ListOptions pageToken(String pageToken) {
+	   checkNotNull(pageToken, "pageToken");
+	   this.queryParameters.removeAll("pageToken");
+      this.queryParameters.put("pageToken", pageToken);
+      return this;
+   }
+
    public static class Builder {
 
       /**
@@ -86,6 +96,13 @@ public class ListOptions extends BaseHttpRequestOptions {
        */
       public ListOptions maxResults(Integer maxResults) {
          return new ListOptions().maxResults(maxResults);
+      }
+
+      /**
+       * @see ListOptions#pageToken(String)
+       */
+      public ListOptions pageToken(String pageToken) {
+         return new ListOptions().pageToken(pageToken);
       }
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/PageSystemExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/PageSystemExpectTest.java
@@ -72,8 +72,8 @@ public class PageSystemExpectTest extends BaseGoogleComputeEngineApiExpectTest {
               .builder()
               .method("GET")
               .endpoint("https://www.googleapis" +
-                      ".com/compute/v1/projects/myproject/global/images?pageToken" +
-                      "=CgVJTUFHRRIbZ29vZ2xlLmNlbnRvcy02LTItdjIwMTIwNjIx&maxResults=3")
+                      ".com/compute/v1/projects/myproject/global/images?maxResults=3&pageToken" +
+                      "=CgVJTUFHRRIbZ29vZ2xlLmNlbnRvcy02LTItdjIwMTIwNjIx")
               .addHeader("Accept", "application/json")
               .addHeader("Authorization", "Bearer " + TOKEN).build();
 
@@ -81,8 +81,8 @@ public class PageSystemExpectTest extends BaseGoogleComputeEngineApiExpectTest {
               .builder()
               .method("GET")
               .endpoint("https://www.googleapis" +
-                      ".com/compute/v1/projects/myproject/global/images?pageToken" +
-                      "=CgVJTUFHRRIbZ29vZ2xlLmdjZWwtMTAtMDQtdjIwMTIxMTA2&maxResults=3")
+                      ".com/compute/v1/projects/myproject/global/images?maxResults=3&pageToken" +
+                      "=CgVJTUFHRRIbZ29vZ2xlLmdjZWwtMTAtMDQtdjIwMTIxMTA2")
               .addHeader("Accept", "application/json")
               .addHeader("Authorization", "Bearer " + TOKEN).build();
 
@@ -100,13 +100,11 @@ public class PageSystemExpectTest extends BaseGoogleComputeEngineApiExpectTest {
               TOKEN_RESPONSE, list1, list1response, list2, list2Response, list3, list3Response)
               .getImageApiForProject("myproject");
 
-      PagedIterable<Image> images = imageApi.list(new ListOptions.Builder().maxResults(3));
+      PagedIterable<Image> images = imageApi.list(new ListOptions.Builder().maxResults(3)).toPagedIterable();
 
       int imageCounter = 0;
       for (IterableWithMarker<Image> page : images) {
-         for (Image image : page) {
-            imageCounter++;
-         }
+         imageCounter += page.size();
       }
       assertSame(imageCounter, 9);
    }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/InstanceInZoneToNodeMetadataTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/InstanceInZoneToNodeMetadataTest.java
@@ -16,9 +16,8 @@
  */
 package org.jclouds.googlecomputeengine.compute.functions;
 
-import static org.easymock.EasyMock.createMock;
-import static org.testng.Assert.assertEquals;
 import static org.jclouds.compute.domain.Image.Status.AVAILABLE;
+import static org.testng.Assert.assertEquals;
 
 import java.net.URI;
 import java.util.Map;
@@ -39,7 +38,6 @@ import org.jclouds.date.internal.SimpleDateFormatDateService;
 import org.jclouds.domain.Location;
 import org.jclouds.domain.LocationBuilder;
 import org.jclouds.domain.LocationScope;
-import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
 import org.jclouds.googlecomputeengine.domain.Instance;
 import org.jclouds.googlecomputeengine.domain.InstanceInZone;
 import org.jclouds.googlecomputeengine.domain.Metadata;
@@ -232,13 +230,6 @@ public class InstanceInZoneToNodeMetadataTest {
          }
       };
 
-      Supplier<String> userProjectSupplier = new Supplier<String>() {
-         @Override
-         public String get() {
-            return "userProject";
-         }
-      };
-
       GroupNamingConvention.Factory namingConventionFactory =
          new GroupNamingConvention.Factory() {
             @Override
@@ -259,9 +250,7 @@ public class InstanceInZoneToNodeMetadataTest {
             imageSupplier,
             hardwareSupplier,
             locationSupplier,
-            new FirewallTagNamingConvention.Factory(namingConventionFactory),
-            createMock(GoogleComputeEngineApi.class),
-            userProjectSupplier);
+            new FirewallTagNamingConvention.Factory(namingConventionFactory));
    }
 
    @Test

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/AddressApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/AddressApiExpectTest.java
@@ -140,7 +140,7 @@ public class AddressApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
       AddressApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, list, operationResponse).getAddressApiForProject("myproject");
 
-      assertEquals(api.listFirstPageInRegion("us-central1").toString(),
+      assertEquals(api.listInRegion("us-central1").first().get().toString(),
               new ParseAddressListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/AddressApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/AddressApiLiveTest.java
@@ -55,7 +55,7 @@ public class AddressApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListAddress() {
 
       PagedIterable<Address> addresss = api().listInRegion(DEFAULT_REGION_NAME, new ListOptions.Builder()
-              .filter("name eq " + ADDRESS_NAME));
+              .filter("name eq " + ADDRESS_NAME)).toPagedIterable();
 
       List<Address> addresssAsList = Lists.newArrayList(addresss.concat());
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiExpectTest.java
@@ -231,7 +231,7 @@ public class DiskApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
       DiskApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, list, operationResponse).getDiskApiForProject("myproject");
 
-      assertEquals(api.listFirstPageInZone("us-central1-a").toString(),
+      assertEquals(api.listInZone("us-central1-a").first().get().toString(),
               new ParseDiskListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
@@ -60,7 +60,7 @@ public class DiskApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListDisk() {
 
       PagedIterable<Disk> disks = api().listInZone(DEFAULT_ZONE_NAME, new ListOptions.Builder()
-              .filter("name eq " + DISK_NAME));
+              .filter("name eq " + DISK_NAME)).toPagedIterable();
 
       List<Disk> disksAsList = Lists.newArrayList(disks.concat());
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskTypeApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskTypeApiExpectTest.java
@@ -97,7 +97,7 @@ public class DiskTypeApiExpectTest extends BaseGoogleComputeEngineApiExpectTest 
               TOKEN_RESPONSE, LIST_DISK_TYPES_REQUEST, LIST_DISK_TYPES_RESPONSE).getDiskTypeApiForProject
               ("myproject");
 
-      assertEquals(diskTypeApi.listFirstPageInZone("us-central1-a").toString(),
+      assertEquals(diskTypeApi.listInZone("us-central1-a").first().get().toString(),
               new ParseDiskTypeListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskTypeApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskTypeApiLiveTest.java
@@ -47,7 +47,7 @@ public class DiskTypeApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testDiskType() {
 
       PagedIterable<DiskType> diskTypes = api().listInZone(DEFAULT_ZONE_NAME, new ListOptions.Builder()
-              .maxResults(1));
+              .maxResults(1)).toPagedIterable();
 
       Iterator<IterableWithMarker<DiskType>> pageIterator = diskTypes.iterator();
       assertTrue(pageIterator.hasNext());

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/FirewallApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/FirewallApiExpectTest.java
@@ -278,7 +278,7 @@ public class FirewallApiExpectTest extends BaseGoogleComputeEngineApiExpectTest 
       FirewallApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, list, operationResponse).getFirewallApiForProject("myproject");
 
-      assertEquals(api.listFirstPage().toString(),
+      assertEquals(api.list().first().get().toString(),
               new ParseFirewallListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/FirewallApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/FirewallApiLiveTest.java
@@ -137,7 +137,7 @@ public class FirewallApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListFirewall() {
 
       PagedIterable<Firewall> firewalls = api().list(new ListOptions.Builder()
-              .filter("name eq " + FIREWALL_NAME));
+              .filter("name eq " + FIREWALL_NAME)).toPagedIterable();
 
       List<Firewall> firewallsAsList = Lists.newArrayList(firewalls.concat());
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalOperationApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalOperationApiExpectTest.java
@@ -109,7 +109,7 @@ public class GlobalOperationApiExpectTest extends BaseGoogleComputeEngineApiExpe
       GlobalOperationApi globalOperationApi = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, get, operationResponse).getGlobalOperationApiForProject("myproject");
 
-      assertEquals(globalOperationApi.listFirstPage().toString(),
+      assertEquals(globalOperationApi.list().first().get().toString(),
               new ParseOperationListTest().expected().toString());
    }
 
@@ -132,10 +132,12 @@ public class GlobalOperationApiExpectTest extends BaseGoogleComputeEngineApiExpe
       GlobalOperationApi globalOperationApi = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, get, operationResponse).getGlobalOperationApiForProject("myproject");
 
-      assertEquals(globalOperationApi.listAtMarker("CglPUEVSQVRJT04SOzU5MDQyMTQ4Nzg1Mi5vcGVyYXRpb24tMTM1Mj" +
-              "I0NDI1ODAzMC00Y2RkYmU2YTJkNmIwLWVkMzIyMzQz",
-              new ListOptions.Builder().filter("status eq done").maxResults(3)).toString(),
-              new ParseOperationListTest().expected().toString());
+      assertEquals(globalOperationApi
+            .list(new ListOptions.Builder()
+                  .pageToken(
+                        "CglPUEVSQVRJT04SOzU5MDQyMTQ4Nzg1Mi5vcGVyYXRpb24tMTM1Mj"
+                              + "I0NDI1ODAzMC00Y2RkYmU2YTJkNmIwLWVkMzIyMzQz").filter("status eq done").maxResults(3))
+            .toPagedIterable().first().get().toString(), new ParseOperationListTest().expected().toString());
    }
 
    public void testListOperationWithPaginationOptionsResponseIs4xx() {

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalOperationApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalOperationApiLiveTest.java
@@ -69,7 +69,7 @@ public class GlobalOperationApiLiveTest extends BaseGoogleComputeEngineApiLiveTe
    public void testListOperationsWithFiltersAndPagination() {
       PagedIterable<Operation> operations = api().list(new ListOptions.Builder()
               .filter("operationType eq setMetadata")
-              .maxResults(1));
+              .maxResults(1)).toPagedIterable();
 
       // make sure that in spite of having only one result per page we get at least two results
       final AtomicInteger counter = new AtomicInteger();

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiExpectTest.java
@@ -144,7 +144,7 @@ public class ImageApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
               TOKEN_RESPONSE, LIST_PROJECT_IMAGES_REQUEST, LIST_PROJECT_IMAGES_RESPONSE).getImageApiForProject
               ("myproject");
 
-      assertEquals(imageApi.listFirstPage().toString(),
+      assertEquals(imageApi.list().first().get().toString(),
               new ParseImageListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiLiveTest.java
@@ -61,7 +61,7 @@ public class ImageApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    @Test(groups = "live")
    public void testListImage() {
 
-      PagedIterable<Image> images = api().list(new ListOptions.Builder().maxResults(1));
+      PagedIterable<Image> images = api().list(new ListOptions.Builder().maxResults(1)).toPagedIterable();
 
       Iterator<IterableWithMarker<Image>> pageIterator = images.iterator();
       assertTrue(pageIterator.hasNext());

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiExpectTest.java
@@ -223,7 +223,7 @@ public class InstanceApiExpectTest extends BaseGoogleComputeEngineApiExpectTest 
               requestForScopes(COMPUTE_READONLY_SCOPE), TOKEN_RESPONSE,
               LIST_INSTANCES_REQUEST, LIST_INSTANCES_RESPONSE).getInstanceApiForProject("myproject");
 
-      assertEquals(api.listFirstPageInZone("us-central1-a").toString(),
+      assertEquals(api.listInZone("us-central1-a").first().get().toString(),
               new ParseInstanceListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
@@ -72,6 +72,7 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
       GoogleComputeEngineApi api = super.create(props, modules);
       URI imageUri = api.getImageApiForProject("centos-cloud")
                         .list(new ListOptions.Builder().filter("name eq centos.*"))
+                        .toPagedIterable()
                         .concat()
                         .filter(new Predicate<Image>() {
                            @Override
@@ -205,7 +206,7 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListInstance() {
 
       PagedIterable<Instance> instances = api().listInZone(DEFAULT_ZONE_NAME, new ListOptions.Builder()
-              .filter("name eq " + INSTANCE_NAME));
+              .filter("name eq " + INSTANCE_NAME)).toPagedIterable();
 
       List<Instance> instancesAsList = Lists.newArrayList(instances.concat());
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/MachineTypeApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/MachineTypeApiExpectTest.java
@@ -97,7 +97,7 @@ public class MachineTypeApiExpectTest extends BaseGoogleComputeEngineApiExpectTe
               TOKEN_RESPONSE, LIST_MACHINE_TYPES_REQUEST, LIST_MACHINE_TYPES_RESPONSE).getMachineTypeApiForProject
               ("myproject");
 
-      assertEquals(machineTypeApi.listFirstPageInZone("us-central1-a").toString(),
+      assertEquals(machineTypeApi.listInZone("us-central1-a").first().get().toString(),
               new ParseMachineTypeListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/MachineTypeApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/MachineTypeApiLiveTest.java
@@ -46,7 +46,7 @@ public class MachineTypeApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListMachineType() {
 
       PagedIterable<MachineType> machineTypes = api().listInZone(DEFAULT_ZONE_NAME, new ListOptions.Builder()
-              .maxResults(1));
+              .maxResults(1)).toPagedIterable();
 
       Iterator<IterableWithMarker<MachineType>> pageIterator = machineTypes.iterator();
       assertTrue(pageIterator.hasNext());

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/NetworkApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/NetworkApiExpectTest.java
@@ -141,7 +141,7 @@ public class NetworkApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
       NetworkApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, list, operationResponse).getNetworkApiForProject("myproject");
 
-      assertEquals(api.listFirstPage().toString(),
+      assertEquals(api.list().first().get().toString(),
               new ParseNetworkListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/NetworkApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/NetworkApiLiveTest.java
@@ -60,7 +60,7 @@ public class NetworkApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListNetwork() {
 
       PagedIterable<Network> networks = api().list(new ListOptions.Builder()
-              .filter("name eq " + NETWORK_NAME));
+              .filter("name eq " + NETWORK_NAME)).toPagedIterable();
 
       List<Network> networksAsList = Lists.newArrayList(networks.concat());
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionApiExpectTest.java
@@ -78,7 +78,7 @@ public class RegionApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
       RegionApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, LIST_REGIONS_REQ, LIST_REGIONS_RESPONSE).getRegionApiForProject("myproject");
 
-      assertEquals(api.listFirstPage().toString(),
+      assertEquals(api.list().first().get().toString(),
               new ParseRegionListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionApiLiveTest.java
@@ -46,7 +46,7 @@ public class RegionApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListRegion() {
 
       PagedIterable<Region> regions = api().list(new ListOptions.Builder()
-              .maxResults(1));
+              .maxResults(1)).toPagedIterable();
 
       Iterator<IterableWithMarker<Region>> pageIterator = regions.iterator();
       assertTrue(pageIterator.hasNext());

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionOperationApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionOperationApiLiveTest.java
@@ -69,7 +69,7 @@ public class RegionOperationApiLiveTest extends BaseGoogleComputeEngineApiLiveTe
    public void testListOperationsWithFiltersAndPagination() {
       PagedIterable<Operation> operations = api().listInRegion(DEFAULT_REGION_NAME, new ListOptions.Builder()
 //              .filter("operationType eq insert")
-              .maxResults(1));
+              .maxResults(1)).toPagedIterable();
 
       // make sure that in spite of having only one result per page we get at least two results
       final AtomicInteger counter = new AtomicInteger();

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RouteApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RouteApiExpectTest.java
@@ -152,7 +152,7 @@ public class RouteApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
       RouteApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, list, operationResponse).getRouteApiForProject("myproject");
 
-      assertEquals(api.listFirstPage().toString(),
+      assertEquals(api.list().first().get().toString(),
               new ParseRouteListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RouteApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RouteApiLiveTest.java
@@ -71,7 +71,7 @@ public class RouteApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListRoute() {
 
       PagedIterable<Route> routes = api().list(new ListOptions()
-              .filter("name eq " + ROUTE_NAME));
+              .filter("name eq " + ROUTE_NAME)).toPagedIterable();
 
       List<Route> routesAsList = Lists.newArrayList(routes.concat());
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/SnapshotApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/SnapshotApiExpectTest.java
@@ -78,7 +78,7 @@ public class SnapshotApiExpectTest extends BaseGoogleComputeEngineApiExpectTest 
       SnapshotApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, LIST_SNAPSHOTS_REQ, LIST_SNAPSHOTS_RESPONSE).getSnapshotApiForProject("myproject");
 
-      assertEquals(api.listFirstPage().toString(),
+      assertEquals(api.list().first().get().toString(),
               new ParseSnapshotListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/SnapshotApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/SnapshotApiLiveTest.java
@@ -66,7 +66,7 @@ public class SnapshotApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListSnapshot() {
 
       PagedIterable<Snapshot> snapshots = api().list(new ListOptions.Builder()
-              .filter("name eq " + SNAPSHOT_NAME));
+              .filter("name eq " + SNAPSHOT_NAME)).toPagedIterable();
 
       List<Snapshot> snapshotsAsList = Lists.newArrayList(snapshots.concat());
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneApiExpectTest.java
@@ -81,7 +81,7 @@ public class ZoneApiExpectTest extends BaseGoogleComputeEngineApiExpectTest {
       ZoneApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, LIST_ZONES_REQ, LIST_ZONES_RESPONSE).getZoneApiForProject("myproject");
 
-      assertEquals(api.listFirstPage().toString(),
+      assertEquals(api.list().first().get().toString(),
               new ParseZoneListTest().expected().toString());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneApiLiveTest.java
@@ -46,7 +46,7 @@ public class ZoneApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testListZone() {
 
       PagedIterable<Zone> zones = api().list(new ListOptions.Builder()
-              .maxResults(1));
+              .maxResults(1)).toPagedIterable();
 
       Iterator<IterableWithMarker<Zone>> pageIterator = zones.iterator();
       assertTrue(pageIterator.hasNext());

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneOperationApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneOperationApiExpectTest.java
@@ -25,8 +25,8 @@ import static org.testng.Assert.assertTrue;
 import java.net.URI;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
-import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineApiExpectTest;
 import org.jclouds.googlecomputeengine.options.ListOptions;
@@ -71,8 +71,8 @@ public class ZoneOperationApiExpectTest extends BaseGoogleComputeEngineApiExpect
               .build();
    }
 
-   private ListPage<Operation> expectedList() {
-      return ListPage.<Operation>builder()
+   private PageWithMarker<Operation> expectedList() {
+      return PageWithMarker.<Operation>builder()
               .kind(Resource.Kind.OPERATION_LIST)
               .addItem(expected())
               .build();
@@ -141,7 +141,7 @@ public class ZoneOperationApiExpectTest extends BaseGoogleComputeEngineApiExpect
       ZoneOperationApi zoneOperationApi = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, get, operationResponse).getZoneOperationApiForProject("myproject");
 
-      assertEquals(zoneOperationApi.listFirstPageInZone("us-central1-a").toString(),
+      assertEquals(zoneOperationApi.listInZone("us-central1-a").first().get().toString(),
               expectedList().toString());
    }
 
@@ -164,11 +164,17 @@ public class ZoneOperationApiExpectTest extends BaseGoogleComputeEngineApiExpect
       ZoneOperationApi zoneOperationApi = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, get, operationResponse).getZoneOperationApiForProject("myproject");
 
-      assertEquals(zoneOperationApi.listAtMarkerInZone("us-central1-a",
-              "CglPUEVSQVRJT04SOzU5MDQyMTQ4Nzg1Mi5vcGVyYXRpb24tMTM1Mj" +
-                      "I0NDI1ODAzMC00Y2RkYmU2YTJkNmIwLWVkMzIyMzQz",
-              new ListOptions.Builder().filter("status eq done").maxResults(3)).toString(),
-              expectedList().toString());
+      assertEquals(
+            zoneOperationApi.listInZone(
+                  "us-central1-a",
+                  new ListOptions.Builder().
+                  pageToken(
+                        "CglPUEVSQVRJT04SOzU5MDQyMTQ4Nzg1Mi5vcGVyYXRpb24tMTM1Mj"
+                              + "I0NDI1ODAzMC00Y2RkYmU2YTJkNmIwLWVkMzIyMzQz")
+                        .filter("status eq done")
+                        .maxResults(3)
+                        ).toPagedIterable().first().get().toString(), expectedList()
+                  .toString());
    }
 
    public void testListOperationWithPaginationOptionsResponseIs4xx() {

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneOperationApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneOperationApiLiveTest.java
@@ -68,7 +68,7 @@ public class ZoneOperationApiLiveTest extends BaseGoogleComputeEngineApiLiveTest
    public void testListOperationsWithFiltersAndPagination() {
       PagedIterable<Operation> operations = api().listInZone(DEFAULT_ZONE_NAME, new ListOptions.Builder()
 //              .filter("operationType eq insert")
-              .maxResults(1));
+              .maxResults(1)).toPagedIterable();
 
       // make sure that in spite of having only one result per page we get at least two results
       final AtomicInteger counter = new AtomicInteger();

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseAddressListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseAddressListTest.java
@@ -23,13 +23,13 @@ import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
 import org.jclouds.googlecomputeengine.domain.Address;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource.Kind;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit")
-public class ParseAddressListTest extends BaseGoogleComputeEngineParseTest<ListPage<Address>> {
+public class ParseAddressListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Address>> {
 
    @Override
    public String resource() {
@@ -38,8 +38,8 @@ public class ParseAddressListTest extends BaseGoogleComputeEngineParseTest<ListP
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Address> expected() {
-      return ListPage.<Address>builder()
+   public PageWithMarker<Address> expected() {
+      return PageWithMarker.<Address>builder()
               .kind(Kind.ADDRESS_LIST)
               .addItem(new ParseAddressTest().expected())
               .addItem(Address.builder()

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskListTest.java
@@ -23,13 +23,13 @@ import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
 import org.jclouds.googlecomputeengine.domain.Disk;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit")
-public class ParseDiskListTest extends BaseGoogleComputeEngineParseTest<ListPage<Disk>> {
+public class ParseDiskListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Disk>> {
 
    @Override
    public String resource() {
@@ -38,8 +38,8 @@ public class ParseDiskListTest extends BaseGoogleComputeEngineParseTest<ListPage
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Disk> expected() {
-      return ListPage.<Disk>builder()
+   public PageWithMarker<Disk> expected() {
+      return PageWithMarker.<Disk>builder()
               .kind(Resource.Kind.DISK_LIST)
               .addItem(Disk.builder()
                       .id("13050421646334304115")

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTypeListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTypeListTest.java
@@ -24,11 +24,11 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
-import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.DiskType;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 
-public class ParseDiskTypeListTest extends BaseGoogleComputeEngineParseTest<ListPage<DiskType>> {
+public class ParseDiskTypeListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<DiskType>> {
 
    @Override
    public String resource() {
@@ -37,9 +37,9 @@ public class ParseDiskTypeListTest extends BaseGoogleComputeEngineParseTest<List
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<DiskType> expected() {
+   public PageWithMarker<DiskType> expected() {
       SimpleDateFormatDateService dateService = new SimpleDateFormatDateService();
-      return ListPage.<DiskType>builder()
+      return PageWithMarker.<DiskType>builder()
               .kind(DISK_TYPE_LIST)
               .addItem(DiskType.builder()
                       .creationTimestamp(dateService.iso8601DateParse("2014-06-02T11:07:28.530-07:00"))

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseFirewallListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseFirewallListTest.java
@@ -23,14 +23,14 @@ import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
 import org.jclouds.googlecomputeengine.domain.Firewall;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.jclouds.net.domain.IpProtocol;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit")
-public class ParseFirewallListTest extends BaseGoogleComputeEngineParseTest<ListPage<Firewall>> {
+public class ParseFirewallListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Firewall>> {
 
    @Override
    public String resource() {
@@ -39,8 +39,8 @@ public class ParseFirewallListTest extends BaseGoogleComputeEngineParseTest<List
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Firewall> expected() {
-      return ListPage.<Firewall>builder()
+   public PageWithMarker<Firewall> expected() {
+      return PageWithMarker.<Firewall>builder()
               .kind(Resource.Kind.FIREWALL_LIST)
               .addItem(new ParseFirewallTest().expected())
               .addItem(Firewall.builder()

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseImageListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseImageListTest.java
@@ -24,13 +24,13 @@ import javax.ws.rs.core.MediaType;
 import org.jclouds.date.internal.SimpleDateFormatDateService;
 import org.jclouds.googlecomputeengine.domain.Deprecated;
 import org.jclouds.googlecomputeengine.domain.Image;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit")
-public class ParseImageListTest extends BaseGoogleComputeEngineParseTest<ListPage<Image>> {
+public class ParseImageListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Image>> {
 
    @Override
    public String resource() {
@@ -39,8 +39,8 @@ public class ParseImageListTest extends BaseGoogleComputeEngineParseTest<ListPag
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Image> expected() {
-      return ListPage.<Image>builder()
+   public PageWithMarker<Image> expected() {
+      return PageWithMarker.<Image>builder()
               .kind(Resource.Kind.IMAGE_LIST)
               .addItem(Image.builder()
                       .id("12941197498378735318")

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceListTest.java
@@ -20,11 +20,11 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.googlecomputeengine.domain.Instance;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 
-public class ParseInstanceListTest extends BaseGoogleComputeEngineParseTest<ListPage<Instance>> {
+public class ParseInstanceListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Instance>> {
 
    @Override
    public String resource() {
@@ -33,8 +33,8 @@ public class ParseInstanceListTest extends BaseGoogleComputeEngineParseTest<List
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Instance> expected() {
-      return ListPage.<Instance>builder()
+   public PageWithMarker<Instance> expected() {
+      return PageWithMarker.<Instance>builder()
               .kind(Resource.Kind.INSTANCE_LIST)
               .addItem(new ParseInstanceTest().expected())
               .build();

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseMachineTypeListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseMachineTypeListTest.java
@@ -24,11 +24,11 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
-import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.MachineType;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 
-public class ParseMachineTypeListTest extends BaseGoogleComputeEngineParseTest<ListPage<MachineType>> {
+public class ParseMachineTypeListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<MachineType>> {
 
    @Override
    public String resource() {
@@ -37,9 +37,9 @@ public class ParseMachineTypeListTest extends BaseGoogleComputeEngineParseTest<L
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<MachineType> expected() {
+   public PageWithMarker<MachineType> expected() {
       SimpleDateFormatDateService dateService = new SimpleDateFormatDateService();
-      return ListPage.<MachineType>builder()
+      return PageWithMarker.<MachineType>builder()
               .kind(MACHINE_TYPE_LIST)
               .addItem(MachineType.builder()
                       .id("4618642685664990776")

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseNetworkListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseNetworkListTest.java
@@ -19,12 +19,12 @@ package org.jclouds.googlecomputeengine.parse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Network;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 
-public class ParseNetworkListTest extends BaseGoogleComputeEngineParseTest<ListPage<Network>> {
+public class ParseNetworkListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Network>> {
 
    @Override
    public String resource() {
@@ -33,8 +33,8 @@ public class ParseNetworkListTest extends BaseGoogleComputeEngineParseTest<ListP
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Network> expected() {
-      return ListPage.<Network>builder()
+   public PageWithMarker<Network> expected() {
+      return PageWithMarker.<Network>builder()
               .kind(Resource.Kind.NETWORK_LIST)
               .addItem(new ParseNetworkTest().expected())
               .build();

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseOperationListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseOperationListTest.java
@@ -19,12 +19,12 @@ package org.jclouds.googlecomputeengine.parse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.googlecomputeengine.domain.ListPage;
 import org.jclouds.googlecomputeengine.domain.Operation;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 
-public class ParseOperationListTest extends BaseGoogleComputeEngineParseTest<ListPage<Operation>> {
+public class ParseOperationListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Operation>> {
 
    @Override
    public String resource() {
@@ -33,8 +33,8 @@ public class ParseOperationListTest extends BaseGoogleComputeEngineParseTest<Lis
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Operation> expected() {
-      return ListPage.<Operation>builder()
+   public PageWithMarker<Operation> expected() {
+      return PageWithMarker.<Operation>builder()
               .kind(Resource.Kind.OPERATION_LIST)
               .addItem(new ParseOperationTest().expected())
               .build();

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRegionListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRegionListTest.java
@@ -22,14 +22,14 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Region;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit")
-public class ParseRegionListTest extends BaseGoogleComputeEngineParseTest<ListPage<Region>> {
+public class ParseRegionListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Region>> {
 
    @Override
    public String resource() {
@@ -38,8 +38,8 @@ public class ParseRegionListTest extends BaseGoogleComputeEngineParseTest<ListPa
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Region> expected() {
-      return ListPage.<Region>builder()
+   public PageWithMarker<Region> expected() {
+      return PageWithMarker.<Region>builder()
                      .kind(Resource.Kind.REGION_LIST)
                      .addItem(new ParseRegionTest().expected())
                      .addItem(Region.builder()

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRouteListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRouteListTest.java
@@ -22,7 +22,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource.Kind;
 import org.jclouds.googlecomputeengine.domain.Route;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 
 @Test(groups = "unit")
-public class ParseRouteListTest extends BaseGoogleComputeEngineParseTest<ListPage<Route>> {
+public class ParseRouteListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Route>> {
 
    @Override
    public String resource() {
@@ -40,8 +40,8 @@ public class ParseRouteListTest extends BaseGoogleComputeEngineParseTest<ListPag
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Route> expected() {
-      return ListPage.<Route>builder()
+   public PageWithMarker<Route> expected() {
+      return PageWithMarker.<Route>builder()
               .kind(Kind.ROUTE_LIST)
               .items(ImmutableList.of(new ParseRouteTest().expected(),
                       Route.builder()

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseSnapshotListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseSnapshotListTest.java
@@ -22,14 +22,14 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource.Kind;
 import org.jclouds.googlecomputeengine.domain.Snapshot;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit")
-public class ParseSnapshotListTest extends BaseGoogleComputeEngineParseTest<ListPage<Snapshot>> {
+public class ParseSnapshotListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Snapshot>> {
 
    @Override
    public String resource() {
@@ -38,8 +38,8 @@ public class ParseSnapshotListTest extends BaseGoogleComputeEngineParseTest<List
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Snapshot> expected() {
-      return ListPage.<Snapshot>builder()
+   public PageWithMarker<Snapshot> expected() {
+      return PageWithMarker.<Snapshot>builder()
               .kind(Kind.SNAPSHOT_LIST)
               .addItem(new ParseSnapshotTest().expected())
               .addItem(Snapshot.builder()

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseZoneListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseZoneListTest.java
@@ -22,14 +22,14 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.date.internal.SimpleDateFormatDateService;
-import org.jclouds.googlecomputeengine.domain.ListPage;
+import org.jclouds.googlecomputeengine.domain.PageWithMarker;
 import org.jclouds.googlecomputeengine.domain.Resource;
 import org.jclouds.googlecomputeengine.domain.Zone;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit")
-public class ParseZoneListTest extends BaseGoogleComputeEngineParseTest<ListPage<Zone>> {
+public class ParseZoneListTest extends BaseGoogleComputeEngineParseTest<PageWithMarker<Zone>> {
 
    @Override
    public String resource() {
@@ -38,8 +38,8 @@ public class ParseZoneListTest extends BaseGoogleComputeEngineParseTest<ListPage
 
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
-   public ListPage<Zone> expected() {
-      return ListPage.<Zone>builder()
+   public PageWithMarker<Zone> expected() {
+      return PageWithMarker.<Zone>builder()
                      .kind(Resource.Kind.ZONE_LIST)
                      .addItem(new ParseZoneTest().expected())
                      .addItem(Zone.builder()


### PR DESCRIPTION
This pull request improves the pagination in GCE so it no longer sucks :D The main changes are:
- Removed all `listFirstPage` and similar methods from all APIs.
- All _list_ methods have two forms: one to list all records that returns a `PagedIterable` (no params), and one to get a concrete page that accepts a `ListOptions` object.
- The `ListPage` object representing a single page has been refactored and improved and now has a convenience method `toPagedIterable`, that allows converting it to iterate over the pages after a filter operation or similar.
- Refactored all parsers to accommodate the new pagination logic.

In summary, every API only has the minimum and meaningful methods to get a list of records, and the pagination domain objects have been reworked to make it trivial to iterate over the pages.

I've also removed most of the warnings in the project.

/cc @ccustine @danbroudy Could you give a try to the branch and run the live tests? Your feedback on how the new pagination methods look like from a user point of view is appreciated too :)
/cc @adriancole Your feedback is also welcome :)
