### PR TITLE
Iteration order of HashSet/Map changes between JRE 7 and JRE 8, breaking tests

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/strategy/internal/SequentialMultipartUploadStrategy.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/strategy/internal/SequentialMultipartUploadStrategy.java
@@ -70,7 +70,7 @@ public class SequentialMultipartUploadStrategy extends MultipartUploadStrategy {
       ObjectTemplate destination = blob2ObjectTemplate.apply(blob.getMetadata());
       ComposeObjectTemplate template = new ComposeObjectTemplate().destination(destination);
 
-      Set<GCSObject> sourceList = Sets.newHashSet();
+      Set<GCSObject> sourceList = Sets.newLinkedHashSet();
 
       String key = blob.getMetadata().getName();
       Payload payload = blob.getPayload();

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/BucketTemplate.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/BucketTemplate.java
@@ -36,14 +36,14 @@ public class BucketTemplate {
 
    protected String name;
    protected Long projectNumber;
-   protected Set<BucketAccessControls> acl = Sets.newHashSet();
-   protected Set<DefaultObjectAccessControls> defaultObjectAccessControls = Sets.newHashSet();
+   protected Set<BucketAccessControls> acl = Sets.newLinkedHashSet();
+   protected Set<DefaultObjectAccessControls> defaultObjectAccessControls = Sets.newLinkedHashSet();
    protected Owner owner;
    protected Location location;
    protected Website website;
    protected Logging logging;
    protected Versioning versioning;
-   protected Set<BucketCors> cors = Sets.newHashSet();
+   protected Set<BucketCors> cors = Sets.newLinkedHashSet();
    protected BucketLifeCycle lifeCycle;
    protected StorageClass storageClass;
 

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/ComposeObjectTemplate.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/ComposeObjectTemplate.java
@@ -28,7 +28,7 @@ public class ComposeObjectTemplate {
 
    protected Kind kind;
    protected ObjectTemplate destination;
-   protected Set<GCSObject> sourceObjects = Sets.newHashSet();
+   protected Set<GCSObject> sourceObjects = Sets.newLinkedHashSet();
 
    public ComposeObjectTemplate() {
       this.kind = Kind.COMPOSE_REQUEST;

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/ObjectTemplate.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/ObjectTemplate.java
@@ -40,8 +40,8 @@ public class ObjectTemplate {
    protected String contentType;
    protected String crc32c;
    protected String md5Hash;
-   private Map<String, String> metadata = Maps.newHashMap();
-   protected Set<ObjectAccessControls> acl = Sets.newHashSet();
+   private Map<String, String> metadata = Maps.newLinkedHashMap();
+   protected Set<ObjectAccessControls> acl = Sets.newLinkedHashSet();
 
    public ObjectTemplate name(String name) {
       this.name = name;

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiLiveTest.java
@@ -226,7 +226,7 @@ public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
                .role(ObjectRole.OWNER).build();
 
       ObjectTemplate destination = new ObjectTemplate().contentType("text/plain").addAcl(oacl);
-      Set<GCSObject> sourceList = Sets.newHashSet();
+      Set<GCSObject> sourceList = Sets.newLinkedHashSet();
       sourceList.add(api().getObject(BUCKET_NAME2, UPLOAD_OBJECT_NAME));
       sourceList.add(api().getObject(BUCKET_NAME2, COPIED_OBJECT_NAME));
 
@@ -245,7 +245,7 @@ public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
    @Test(groups = "live", dependsOnMethods = "testComposeObject")
    public void testComposeObjectWithOptions() {
       ObjectTemplate destination = new ObjectTemplate().contentType(MediaType.APPLICATION_JSON);
-      Set<GCSObject> sourceList = Sets.newHashSet();
+      Set<GCSObject> sourceList = Sets.newLinkedHashSet();
       sourceList.add(api().getObject(BUCKET_NAME2, UPLOAD_OBJECT_NAME));
       sourceList.add(api().getObject(BUCKET_NAME2, COPIED_OBJECT_NAME));
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineService.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineService.java
@@ -161,7 +161,7 @@ public class GoogleComputeEngineService extends BaseComputeService {
          }
       };
 
-      Set<AtomicReference<Operation>> operations = Sets.newHashSet();
+      Set<AtomicReference<Operation>> operations = Sets.newLinkedHashSet();
       for (Firewall firewall : firewallApi.list().concat().filter(firewallBelongsToNetwork)) {
          operations.add(new AtomicReference<Operation>(firewallApi.delete(firewall.getName())));
       }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/strategy/CreateNodesWithGroupEncodedIntoNameThenAddToSet.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/strategy/CreateNodesWithGroupEncodedIntoNameThenAddToSet.java
@@ -150,7 +150,7 @@ public class CreateNodesWithGroupEncodedIntoNameThenAddToSet extends
 
       String projectName = userProject.get();
       FirewallApi firewallApi = api.getFirewallApiForProject(projectName);
-      Set<AtomicReference<Operation>> operations = Sets.newHashSet();
+      Set<AtomicReference<Operation>> operations = Sets.newLinkedHashSet();
 
       for (Integer port : templateOptions.getInboundPorts()) {
          String name = naming.name(port);


### PR DESCRIPTION
Overhead of LinkedHashSet/Map is vs is inconsequential. When porting production code to not break tests across JRE 7 and 8 at square, we wild-carded this change after peer review. It is safe.
