### PR TITLE
ProjectApi Live Test Fix.

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ProjectApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/ProjectApi.java
@@ -30,9 +30,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.googlecomputeengine.domain.Operation;
 import org.jclouds.googlecomputeengine.domain.Project;
+import org.jclouds.googlecomputeengine.handlers.GoogleFallback.NullOn400or404;
 import org.jclouds.googlecomputeengine.binders.MetadataBinder;
 import org.jclouds.oauth.v2.config.OAuthScopes;
 import org.jclouds.oauth.v2.filters.OAuthAuthenticationFilter;
@@ -59,7 +59,7 @@ public interface ProjectApi {
    @GET
    @OAuthScopes(COMPUTE_READONLY_SCOPE)
    @Consumes(MediaType.APPLICATION_JSON)
-   @Fallback(NullOnNotFoundOr404.class)
+   @Fallback(NullOn400or404.class)
    @Path("/projects/{project}")
    Project get(@PathParam("project") String projectName);
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/handlers/GoogleFallback.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/handlers/GoogleFallback.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.handlers;
+
+import static com.google.common.base.Throwables.propagate;
+import static org.jclouds.http.HttpUtils.returnValueOnCodeOrNull;
+
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Predicates.in;
+import static com.google.common.primitives.Ints.asList;
+
+import org.jclouds.Fallback;
+
+public final class GoogleFallback {
+   private GoogleFallback() {
+   }
+
+   public static class NullOn400or404 implements Fallback<Object> {
+      @Override
+      public Object createOrPropagate(Throwable t) throws Exception {
+         Boolean returnVal = returnValueOnCodeOrNull(checkNotNull(t, "throwable"), false, in(asList(400, 404)));
+         if (returnVal != null)
+            return null;
+         throw propagate(t);
+      }
+   }
+}


### PR DESCRIPTION
Broken live test
ProjectApiLiveTest.testGetProjectWhenNotExists:61 » HttpResponse command: GET ...

Failure dues to Google return value change.
Updates the project api to have an appropriate fallback. 
