### PR TITLE
Cleanup ListPage in google apis.

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/ListPage.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/ListPage.java
@@ -16,32 +16,31 @@
  */
 package org.jclouds.googlecloudstorage.domain;
 
+import static org.jclouds.googlecloudstorage.internal.NullSafeCopies.copyOf;
+
 import java.beans.ConstructorProperties;
 import java.util.List;
 
 import org.jclouds.javax.annotation.Nullable;
 
 import com.google.common.collect.ForwardingList;
-import com.google.common.collect.ImmutableList;
 
-/**
- * The collection returned from any <code>listFirstPage()</code> method.
- */
+/** An immutable list that includes a token, if there is another page available. */
 public final class ListPage<T> extends ForwardingList<T> {
 
    private final List<T> items;
    private final String nextPageToken;
    private final List<String> prefixes;
 
-   public static <T> ListPage<T> create(Iterable<T> items, String nextPageToken, List<String> prefixes) {
+   public static <T> ListPage<T> create(List<T> items, String nextPageToken, List<String> prefixes) {
       return new ListPage<T>(items, nextPageToken, prefixes);
    }
 
    @ConstructorProperties({ "items", "nextPageToken", "prefixes" })
-   ListPage(Iterable<T> items, String nextPageToken, List<String> prefixes) {
-      this.items = items != null ? ImmutableList.copyOf(items) : ImmutableList.<T>of();
+   ListPage(List<T> items, String nextPageToken, List<String> prefixes) {
+      this.items = copyOf(items);
       this.nextPageToken = nextPageToken;
-      this.prefixes = prefixes != null ? prefixes : ImmutableList.<String>of();
+      this.prefixes = copyOf(prefixes);
    }
 
    @Nullable public String nextPageToken() {

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineFallbacks.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineFallbacks.java
@@ -37,7 +37,7 @@ public final class GoogleComputeEngineFallbacks {
    }
    public static final class EmptyListPageOnNotFoundOr404 implements Fallback<Object> {
       @Override public ListPage<Object> createOrPropagate(Throwable t) throws Exception {
-         return valOnNotFoundOr404(ListPage.create(null, null, null), t);
+         return valOnNotFoundOr404(ListPage.create(null, null), t);
       }
    }
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/ListPage.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/ListPage.java
@@ -25,32 +25,24 @@ import org.jclouds.javax.annotation.Nullable;
 
 import com.google.common.collect.ForwardingList;
 
-/**
- * The collection returned from any <code>listFirstPage()</code> method.
- */
+/** An immutable list that includes a token, if there is another page available. */
 public final class ListPage<T> extends ForwardingList<T> {
 
    private final List<T> items;
    private final String nextPageToken;
-   private final List<String> prefixes;
 
-   public static <T> ListPage<T> create(List<T> items, String nextPageToken, List<String> prefixes) {
-      return new ListPage<T>(items, nextPageToken, prefixes);
+   public static <T> ListPage<T> create(List<T> items, String nextPageToken) {
+      return new ListPage<T>(items, nextPageToken);
    }
 
-   @ConstructorProperties({ "items", "nextPageToken", "prefixes" })
-   ListPage(List<T> items, String nextPageToken, List<String> prefixes) {
+   @ConstructorProperties({ "items", "nextPageToken" })
+   ListPage(List<T> items, String nextPageToken) {
       this.items = copyOf(items);
       this.nextPageToken = nextPageToken;
-      this.prefixes = copyOf(prefixes);
    }
 
    @Nullable public String nextPageToken() {
       return nextPageToken;
-   }
-
-   public List<String> prefixes() {
-      return prefixes;
    }
 
    @Override protected List<T> delegate() {

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/HttpHealthCheckApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/HttpHealthCheckApiLiveTest.java
@@ -27,6 +27,8 @@ import org.jclouds.googlecomputeengine.options.HttpHealthCheckCreationOptions;
 import org.jclouds.googlecomputeengine.options.ListOptions;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Iterables;
+
 public class HttpHealthCheckApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    private static final String HTTP_HEALTH_CHECK_NAME = "http-health-check-api-live-test";
@@ -69,7 +71,7 @@ public class HttpHealthCheckApiLiveTest extends BaseGoogleComputeEngineApiLiveTe
    public void testListHttpHealthCheck() {
       ListPage<HttpHealthCheck> httpHealthCheck = api().list(new ListOptions.Builder()
               .filter("name eq " + HTTP_HEALTH_CHECK_NAME));
-      assertEquals(httpHealthCheck.size(), 1);
+      assertEquals(Iterables.size(httpHealthCheck), 1);
    }
 
    @Test(groups = "live", dependsOnMethods = "testGetHttpHealthCheck")

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionOperationApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/RegionOperationApiExpectTest.java
@@ -53,8 +53,7 @@ public class RegionOperationApiExpectTest extends BaseGoogleComputeEngineApiExpe
    private ListPage<Operation> expectedList() {
       return ListPage.create( //
             ImmutableList.of(new ParseRegionOperationTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/TargetPoolApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/TargetPoolApiLiveTest.java
@@ -40,6 +40,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 
 public class TargetPoolApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
@@ -205,10 +206,9 @@ public class TargetPoolApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    @Test(groups = "live", dependsOnMethods = "testInsertTargetPool")
    public void testListTargetPool() {
-
       ListPage<TargetPool> targetPool = api().list(new ListOptions.Builder()
               .filter("name eq " + BACKUP_TARGETPOOL_NAME));
-      assertEquals(targetPool.size(), 1);
+      assertEquals(Iterables.size(targetPool), 1);
    }
 
    @Test(groups = "live", dependsOnMethods = {"testInsertTargetPool2"})

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneOperationApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ZoneOperationApiExpectTest.java
@@ -100,8 +100,7 @@ public class ZoneOperationApiExpectTest extends BaseGoogleComputeEngineApiExpect
    private static ListPage<Operation> expectedList() {
       return ListPage.create( //
             ImmutableList.of(new ParseZoneOperationTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseAddressListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseAddressListTest.java
@@ -52,8 +52,7 @@ public class ParseAddressListTest extends BaseGoogleComputeEngineParseTest<ListP
       );
       return ListPage.create( //
             ImmutableList.of(address1, address2), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskListTest.java
@@ -39,8 +39,7 @@ public class ParseDiskListTest extends BaseGoogleComputeEngineParseTest<ListPage
    public ListPage<Disk> expected() {
       return ListPage.create( //
             ImmutableList.of(new ParseDiskTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTypeListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseDiskTypeListTest.java
@@ -52,8 +52,7 @@ public class ParseDiskTypeListTest extends BaseGoogleComputeEngineParseTest<List
       DiskType diskType2 = new ParseDiskTypeTest().expected();
       return ListPage.create( //
             ImmutableList.of(diskType1, diskType2), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseFirewallListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseFirewallListTest.java
@@ -53,8 +53,7 @@ public class ParseFirewallListTest extends BaseGoogleComputeEngineParseTest<List
       );
       return ListPage.create( //
             ImmutableList.of(firewall1, firewall2), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseForwardingRuleListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseForwardingRuleListTest.java
@@ -39,8 +39,7 @@ public class ParseForwardingRuleListTest extends BaseGoogleComputeEngineParseTes
    public ListPage<ForwardingRule> expected() {
       return ListPage.create( //
             ImmutableList.of(new ParseForwardingRuleTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseGlobalOperationListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseGlobalOperationListTest.java
@@ -39,8 +39,7 @@ public class ParseGlobalOperationListTest extends BaseGoogleComputeEngineParseTe
    public ListPage<Operation> expected() {
       return ListPage.create( //
             ImmutableList.of(new ParseGlobalOperationTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseHttpHealthCheckListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseHttpHealthCheckListTest.java
@@ -70,8 +70,7 @@ public class ParseHttpHealthCheckListTest extends BaseGoogleComputeEngineParseTe
       );
       return ListPage.create( //
             ImmutableList.of(healthCheck1, healthCheck2, healthCheck3), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseImageListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseImageListTest.java
@@ -38,8 +38,7 @@ public class ParseImageListTest extends BaseGoogleComputeEngineParseTest<ListPag
    public ListPage<Image> expected() {
       return ListPage.create( //
             ImmutableList.of(new ParseImageTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceListTest.java
@@ -39,8 +39,7 @@ public class ParseInstanceListTest extends BaseGoogleComputeEngineParseTest<List
    public ListPage<Instance> expected() {
       return ListPage.create( //
             ImmutableList.of(new ParseInstanceTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseMachineTypeListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseMachineTypeListTest.java
@@ -80,8 +80,7 @@ public class ParseMachineTypeListTest extends BaseGoogleComputeEngineParseTest<L
       );
       return ListPage.create( //
             ImmutableList.of(machineType1, machineType2, machineType3), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseNetworkListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseNetworkListTest.java
@@ -39,8 +39,7 @@ public class ParseNetworkListTest extends BaseGoogleComputeEngineParseTest<ListP
    public ListPage<Network> expected() {
       return ListPage.create( //
             ImmutableList.of(new ParseNetworkTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRegionListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRegionListTest.java
@@ -61,8 +61,7 @@ public class ParseRegionListTest extends BaseGoogleComputeEngineParseTest<ListPa
       );
       return ListPage.create( //
             ImmutableList.of(region1, region2), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRouteListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseRouteListTest.java
@@ -56,8 +56,7 @@ public class ParseRouteListTest extends BaseGoogleComputeEngineParseTest<ListPag
       );
       return ListPage.create( //
             ImmutableList.of(route1, route2), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseSnapshotListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseSnapshotListTest.java
@@ -52,8 +52,7 @@ public class ParseSnapshotListTest extends BaseGoogleComputeEngineParseTest<List
       );
       return ListPage.create( //
             ImmutableList.of(snapshot1, snapshot2), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseTargetPoolListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseTargetPoolListTest.java
@@ -39,8 +39,7 @@ public class ParseTargetPoolListTest extends BaseGoogleComputeEngineParseTest<Li
    public ListPage<TargetPool> expected() {
       return ListPage.create( //
             ImmutableList.of(new ParseTargetPoolTest().expected()), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseZoneListTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseZoneListTest.java
@@ -57,8 +57,7 @@ public class ParseZoneListTest extends BaseGoogleComputeEngineParseTest<ListPage
       );
       return ListPage.create( //
             ImmutableList.of(zone1, zone2), // items
-            null, // nextPageToken
-            null // prefixes
+            null // nextPageToken
       );
    }
 }


### PR DESCRIPTION
Be consistent, but recognize that google storage has a list of prefixes, where google compute engine does not.
