### PR TITLE
Use images from all public projects and filter deprecated ones

### DIFF
--- a/google-compute-engine/pom.xml
+++ b/google-compute-engine/pom.xml
@@ -39,7 +39,7 @@
         </test.google-compute-engine.credential>
         <test.google-compute-engine.api-version>v1</test.google-compute-engine.api-version>
         <test.google-compute-engine.build-version/>
-        <test.google-compute-engine.template>imageId=debian-7-wheezy-v20131120,locationId=us-central1-a,minRam=2048</test.google-compute-engine.template>
+        <test.google-compute-engine.template>imageNameMatches=debian-7-wheezy-v[0-9]*,locationId=us-central1-a,minRam=2048</test.google-compute-engine.template>
     </properties>
 
     <dependencies>

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineApiMetadata.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineApiMetadata.java
@@ -18,6 +18,7 @@ package org.jclouds.googlecomputeengine;
 
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.compute.config.ComputeServiceProperties.TEMPLATE;
+import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.GCE_IMAGE_PROJECTS;
 import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.GCE_PROVIDER_NAME;
 import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.OPERATION_COMPLETE_INTERVAL;
 import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.OPERATION_COMPLETE_TIMEOUT;
@@ -66,6 +67,7 @@ public class GoogleComputeEngineApiMetadata extends BaseHttpApiMetadata<GoogleCo
       properties.setProperty(TEMPLATE, "osFamily=DEBIAN,osVersionMatches=7\\..*,locationId=us-central1-a,loginUser=jclouds");
       properties.put(OPERATION_COMPLETE_INTERVAL, 500);
       properties.put(OPERATION_COMPLETE_TIMEOUT, 600000);
+      properties.put(GCE_IMAGE_PROJECTS, "centos-cloud,debian-cloud,rhel-cloud,suse-cloud,opensuse-cloud,gce-nvme,coreos-cloud");
       return properties;
    }
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineConstants.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineConstants.java
@@ -31,10 +31,6 @@ public final class GoogleComputeEngineConstants {
     */
    public static final String GOOGLE_PROJECT = "google";
 
-   public static final String CENTOS_PROJECT = "centos-cloud";
-
-   public static final String DEBIAN_PROJECT = "debian-cloud";
-
    public static final String COMPUTE_SCOPE = "https://www.googleapis.com/auth/compute";
 
    public static final String COMPUTE_READONLY_SCOPE = "https://www.googleapis.com/auth/compute.readonly";
@@ -58,6 +54,12 @@ public final class GoogleComputeEngineConstants {
 
    public static final Location GOOGLE_PROVIDER_LOCATION = new LocationBuilder().scope(LocationScope.PROVIDER).id
            (GCE_PROVIDER_NAME).description(GCE_PROVIDER_NAME).build();
+
+   /**
+    * The list of projects that will be scanned looking for images.
+    */
+   @Beta
+   public static final String GCE_IMAGE_PROJECTS = "jclouds.google-compute-engine.image-projects";
 
 
    /**

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
@@ -20,8 +20,10 @@ import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.googlecomputeengine.internal.ListPages.concat;
+import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.GCE_IMAGE_PROJECTS;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -81,6 +83,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
+import com.google.common.base.Splitter;
 import com.google.common.base.Supplier;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -280,5 +283,12 @@ public class GoogleComputeEngineServiceContextModule
    @Provides
    protected Map<Instance.Status, NodeMetadata.Status> toPortableNodeStatus() {
       return toPortableNodeStatus;
+   }
+
+   @Singleton
+   @Provides
+   @Named(GCE_IMAGE_PROJECTS)
+   protected List<String> imageProjects(@Named(GCE_IMAGE_PROJECTS) String imageProjects) {
+      return Splitter.on(',').splitToList(imageProjects);
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.COMPUTE_READONLY_SCOPE;
 import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.COMPUTE_SCOPE;
 import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.GCE_BOOT_DISK_SUFFIX;
+import static org.jclouds.googlecomputeengine.GoogleComputeEngineConstants.GCE_IMAGE_PROJECTS;
 import static org.jclouds.googlecomputeengine.features.GlobalOperationApiExpectTest.GET_GLOBAL_OPERATION_REQUEST;
 import static org.jclouds.googlecomputeengine.features.GlobalOperationApiExpectTest.GET_GLOBAL_OPERATION_RESPONSE;
 import static org.jclouds.googlecomputeengine.features.ImageApiExpectTest.LIST_CENTOS_IMAGES_REQUEST;
@@ -217,6 +218,7 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
    protected Properties setupProperties() {
       Properties overrides = super.setupProperties();
       overrides.put("google-compute-engine.identity", "myproject");
+      overrides.put(GCE_IMAGE_PROJECTS, "debian-cloud,centos-cloud");
       try {
          overrides.put("google-compute-engine.credential", toStringAndClose(getClass().getResourceAsStream("/testpk.pem")));
       } catch (IOException e) {


### PR DESCRIPTION
This is just a proposal. I still haven't run the live tests, as I want some feedback before.

This change removes the hardcoded _debian-cloud_ and _centos-cloud_ projects as the only sources of images, and moves that to a property users can override. I've added to that property all projects that seem to be public (at least the ones where the images I see in the console belong).

It also adds a property to control whether jclouds should return the deprecated images or not, to make it easier for users to pick the right images. Both properties have the corresponding defaults in the api metadata.

@danbroudy @adriancole WDYT?
