### PR TITLE
Remove creepy and unused extensibility.

### DIFF
--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/internal/BaseGoogleCloudStorageExpectTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/internal/BaseGoogleCloudStorageExpectTest.java
@@ -51,11 +51,12 @@ import org.jclouds.io.Payload;
 import org.jclouds.io.payloads.ByteSourcePayload;
 import org.jclouds.oauth.v2.OAuthConstants;
 import org.jclouds.oauth.v2.config.OAuthProperties;
+import org.jclouds.oauth.v2.functions.BuildTokenRequest;
 import org.jclouds.rest.internal.BaseRestApiExpectTest;
 import org.jclouds.ssh.SshKeys;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Resources;
 import com.google.inject.Binder;
@@ -89,9 +90,9 @@ public class BaseGoogleCloudStorageExpectTest<T> extends BaseRestApiExpectTest<T
       return new Module() {
          @Override
          public void configure(Binder binder) {
-            // Predicatable time
-            binder.bind(new TypeLiteral<Supplier<Long>>() {
-            }).toInstance(Suppliers.ofInstance(0L));
+            // Predictable time
+            binder.bind(BuildTokenRequest.class).to(BuildTokenRequest.WithConstantIssuedAt.class);
+
             try {
                KeyFactory keyfactory = KeyFactory.getInstance("RSA");
                PrivateKey privateKey = keyfactory.generatePrivate(privateKeySpec(ByteSource.wrap(PRIVATE_KEY

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineExpectTest.java
@@ -52,13 +52,13 @@ import org.jclouds.http.HttpResponse;
 import org.jclouds.io.Payload;
 import org.jclouds.oauth.v2.OAuthConstants;
 import org.jclouds.oauth.v2.config.OAuthProperties;
+import org.jclouds.oauth.v2.functions.BuildTokenRequest;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.rest.internal.BaseRestApiExpectTest;
 import org.jclouds.ssh.SshKeys;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.io.ByteSource;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -116,7 +116,8 @@ public class BaseGoogleComputeEngineExpectTest<T> extends BaseRestApiExpectTest<
          @Override
          public void configure(Binder binder) {
             // Predictable time
-            binder.bind(new TypeLiteral<Supplier<Long>>() {}).toInstance(Suppliers.ofInstance(0L));
+            binder.bind(BuildTokenRequest.class).to(BuildTokenRequest.WithConstantIssuedAt.class);
+
             Crypto crypto = createMock(Crypto.class);
             KeyPairGenerator rsaKeyPairGenerator = createMock(KeyPairGenerator.class);
             SecureRandom secureRandom = createMock(SecureRandom.class);

--- a/oauth/README
+++ b/oauth/README
@@ -7,8 +7,6 @@ oauth.endpoint - the endpoint to use for authentication (e.g., "http://accounts.
 oauth.audience - the "audience" of the token request (e.g., "http://accounts.google.com/o/oauth2/token" in Google Api's)
 
 Optional:
-- each application may expose a Map<String,String> of additional claims to be added to the token request,
-these should be annotated/named with "oauth.additional-claims"
 oauth.signature-or-mac-algorithm  - the algorithms to use when signing the token request.
 
 Running the live test:

--- a/oauth/src/main/java/org/jclouds/oauth/v2/OAuthConstants.java
+++ b/oauth/src/main/java/org/jclouds/oauth/v2/OAuthConstants.java
@@ -20,21 +20,15 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
-/**
- * The constants for OAuth \
- */
 public final class OAuthConstants {
 
-   /**
-    * Selected algorithm when a signature or mac isn't required.
-    */
+   /** Selected algorithm when a signature or mac isn't required. */
    public static final String NO_ALGORITHM = "none";
 
    /**
     * Static mapping between the oauth algorithm name and the Crypto provider signature algorithm name.
     *
     * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-06#section-3.1">doc</a>
-    * @see org.jclouds.oauth.v2.json.JWTTokenRequestFormat
     */
    public static final Map<String, String> OAUTH_ALGORITHM_NAMES_TO_SIGNATURE_ALGORITHM_NAMES = ImmutableMap
            .<String, String>builder()
@@ -67,12 +61,6 @@ public final class OAuthConstants {
            .put("ES512", "EC")
            .put(NO_ALGORITHM, NO_ALGORITHM).build();
 
-   /**
-    * The (optional) set of additional claims to use, provided in Map<String,String> form
-    */
-   public static final String ADDITIONAL_CLAIMS = "jclouds.oauth.additional-claims";
-
    private OAuthConstants() {
-      throw new AssertionError("intentionally unimplemented");
    }
 }

--- a/oauth/src/main/java/org/jclouds/oauth/v2/config/OAuthProperties.java
+++ b/oauth/src/main/java/org/jclouds/oauth/v2/config/OAuthProperties.java
@@ -16,9 +16,6 @@
  */
 package org.jclouds.oauth.v2.config;
 
-/**
- * Configurable properties for jclouds OAuth
- */
 public class OAuthProperties {
 
    /**
@@ -37,15 +34,9 @@ public class OAuthProperties {
    public static final String AUDIENCE = "jclouds.oauth.audience";
 
    /**
-    * Optional list of comma-separated scopes to use when no OAuthScopes annotation is present.
-    */
-   public static final String SCOPES = "jclouds.oauth.scopes";
-
-   /**
     * Specify if credentials are id + private key or if you are reusing an oauth2 token.
     *
     * @see org.jclouds.oauth.v2.config.CredentialType
     */
    public static final String CREDENTIAL_TYPE = "jclouds.oauth.credential-type";
-
 }

--- a/oauth/src/main/java/org/jclouds/oauth/v2/config/OAuthScopes.java
+++ b/oauth/src/main/java/org/jclouds/oauth/v2/config/OAuthScopes.java
@@ -16,11 +16,12 @@
  */
 package org.jclouds.oauth.v2.config;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
 
 /**
  * Used to annotate REST methods/ifaces that use OAuthAuthentication.
@@ -32,9 +33,6 @@ import java.lang.annotation.Target;
 @Qualifier
 public @interface OAuthScopes {
 
-   /**
-    * @return the OAuth scopes required to access the resource.
-    */
+   /** The OAuth scopes required to access the resource. */
    String[] value();
-
 }

--- a/oauth/src/main/java/org/jclouds/oauth/v2/filters/OAuthAuthenticationFilter.java
+++ b/oauth/src/main/java/org/jclouds/oauth/v2/filters/OAuthAuthenticationFilter.java
@@ -18,10 +18,7 @@ package org.jclouds.oauth.v2.filters;
 
 import org.jclouds.http.HttpRequestFilter;
 
-/**
- * Marker interface to specify auth mechanism (credentials or bearer token)
- *
- */
+/** Marker interface to specify auth mechanism (credentials or bearer token). */
 public interface OAuthAuthenticationFilter extends HttpRequestFilter {
 
 }

--- a/oauth/src/test/java/org/jclouds/oauth/v2/features/OAuthApiLiveTest.java
+++ b/oauth/src/test/java/org/jclouds/oauth/v2/features/OAuthApiLiveTest.java
@@ -19,7 +19,6 @@ package org.jclouds.oauth.v2.features;
 import static com.google.common.base.Preconditions.checkState;
 import static org.jclouds.oauth.v2.OAuthTestUtils.getMandatoryProperty;
 import static org.jclouds.oauth.v2.config.OAuthProperties.AUDIENCE;
-import static org.jclouds.oauth.v2.config.OAuthProperties.SCOPES;
 import static org.jclouds.oauth.v2.config.OAuthProperties.SIGNATURE_OR_MAC_ALGORITHM;
 import static org.jclouds.oauth.v2.domain.Claims.EXPIRATION_TIME;
 import static org.jclouds.oauth.v2.domain.Claims.ISSUED_AT;
@@ -56,7 +55,6 @@ public class OAuthApiLiveTest extends BaseOAuthApiLiveTest {
    protected Properties setupProperties() {
       properties = super.setupProperties();
       return properties;
-
    }
 
    @Test(groups = "live", singleThreaded = true)
@@ -68,7 +66,7 @@ public class OAuthApiLiveTest extends BaseOAuthApiLiveTest {
 
       Header header = Header.create(signatureAlgorithm, "JWT");
 
-      String scopes = getMandatoryProperty(properties, SCOPES);
+      String scopes = getMandatoryProperty(properties, "jclouds.oauth.scopes");
       String audience = getMandatoryProperty(properties, AUDIENCE);
 
       long now = nowInSeconds();

--- a/oauth/src/test/java/org/jclouds/oauth/v2/features/OAuthApiMockTest.java
+++ b/oauth/src/test/java/org/jclouds/oauth/v2/features/OAuthApiMockTest.java
@@ -74,10 +74,10 @@ public class OAuthApiMockTest {
 
    public void testGenerateJWTRequest() throws Exception {
       MockWebServer server = new MockWebServer();
-      server.enqueue(new MockResponse().setBody("{\n" +
-                  "  \"access_token\" : \"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M\",\n" +
-                  "  \"token_type\" : \"Bearer\",\n" +
-                  "  \"expires_in\" : 3600\n" +
+      server.enqueue(new MockResponse().setBody("{" +
+                  "  \"access_token\" : \"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M\"," +
+                  "  \"token_type\" : \"Bearer\"," +
+                  "  \"expires_in\" : 3600" +
                   "}"));
       server.play();
 

--- a/oauth/src/test/java/org/jclouds/oauth/v2/internal/BaseOAuthApiLiveTest.java
+++ b/oauth/src/test/java/org/jclouds/oauth/v2/internal/BaseOAuthApiLiveTest.java
@@ -19,7 +19,6 @@ package org.jclouds.oauth.v2.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.oauth.v2.OAuthTestUtils.setCredential;
 import static org.jclouds.oauth.v2.config.OAuthProperties.AUDIENCE;
-import static org.jclouds.oauth.v2.config.OAuthProperties.SCOPES;
 import static org.jclouds.oauth.v2.config.OAuthProperties.SIGNATURE_OR_MAC_ALGORITHM;
 
 import java.util.Properties;
@@ -43,7 +42,7 @@ public class BaseOAuthApiLiveTest extends BaseApiLiveTest<OAuthApi> {
       setCredential(props, "oauth.credential");
       checkNotNull(setIfTestSystemPropertyPresent(props, "oauth.endpoint"), "test.oauth.endpoint must be set");
       checkNotNull(setIfTestSystemPropertyPresent(props, AUDIENCE), "test.jclouds.oauth.audience must be set");
-      setIfTestSystemPropertyPresent(props, SCOPES);
+      setIfTestSystemPropertyPresent(props, "jclouds.oauth.scopes");
       setIfTestSystemPropertyPresent(props, SIGNATURE_OR_MAC_ALGORITHM);
       return props;
    }


### PR DESCRIPTION
Optional injection is one of the scariest things in guice.
Outside tests, we have not needed these extension points in 2 years: we can kill them.
