### PR TITLE
Remove tests for default fallbacks

### DIFF
--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiExpectTest.java
@@ -32,7 +32,6 @@ import org.jclouds.googlecomputeengine.parse.ParseDiskTest;
 import org.jclouds.googlecomputeengine.parse.ParseZoneOperationTest;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
-import org.jclouds.rest.ResourceNotFoundException;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "DiskApiExpectTest")
@@ -54,8 +53,7 @@ public class DiskApiExpectTest extends BaseGoogleComputeEngineExpectTest<GoogleC
       DiskApi api = requestsSendResponses(requestForScopes(COMPUTE_READONLY_SCOPE),
               TOKEN_RESPONSE, get, response).disksInZone("us-central1-a");
 
-      assertEquals(api.get("testimage1"),
-              new ParseDiskTest().expected());
+      assertEquals(api.get("testimage1"), new ParseDiskTest().expected());
    }
 
    public void testGetDiskResponseIs4xx() throws Exception {
@@ -153,28 +151,7 @@ public class DiskApiExpectTest extends BaseGoogleComputeEngineExpectTest<GoogleC
               TOKEN_RESPONSE, createSnapshotRequest,
               createSnapshotResponse).disksInZone("us-central1-a");
 
-      assertEquals(api.createSnapshot("testimage1", "test-snap"),
-            new ParseZoneOperationTest().expected());
-   }
-
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testCreateSnapshotResponseIs4xx() {
-      HttpRequest createSnapshotRequest = HttpRequest
-              .builder()
-              .method("POST")
-              .endpoint(BASE_URL + "/party/zones/us-central1-a/disks/testimage1/createSnapshot")
-              .addHeader("Accept", "application/json")
-              .addHeader("Authorization", "Bearer " + TOKEN)
-              .payload(payloadFromResourceWithContentType("/disk_create_snapshot.json", MediaType.APPLICATION_JSON))
-              .build();
-
-      HttpResponse createSnapshotResponse = HttpResponse.builder().statusCode(404).build();
-
-      DiskApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, createSnapshotRequest,
-              createSnapshotResponse).disksInZone("us-central1-a");
-
-      api.createSnapshot("testimage1", "test-snap");
+      assertEquals(api.createSnapshot("testimage1", "test-snap"), new ParseZoneOperationTest().expected());
    }
 
    public void testDeleteDiskResponseIs2xx() {

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/HttpHealthCheckApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/HttpHealthCheckApiExpectTest.java
@@ -30,7 +30,6 @@ import org.jclouds.googlecomputeengine.parse.ParseHttpHealthCheckListTest;
 import org.jclouds.googlecomputeengine.parse.ParseHttpHealthCheckTest;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
-import org.jclouds.rest.ResourceNotFoundException;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "HttpHealthCheckApiExpectTest")
@@ -88,27 +87,6 @@ public class HttpHealthCheckApiExpectTest extends BaseGoogleComputeEngineExpectT
               insertHttpHealthCheckResponse).httpHeathChecks();
       HttpHealthCheckCreationOptions options = new HttpHealthCheckCreationOptions().timeoutSec(0).unhealthyThreshold(0);
       assertEquals(api.insert("http-health-check", options), new ParseGlobalOperationTest().expected());
-   }
-
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testInsertHttpHealthCheckResponseIs4xx() {
-      HttpRequest create = HttpRequest
-              .builder()
-              .method("POST")
-              .endpoint(BASE_URL + "/party/global/httpHealthChecks")
-              .addHeader("Accept", "application/json")
-              .addHeader("Authorization", "Bearer " + TOKEN)
-              .payload(payloadFromResourceWithContentType("/httphealthcheck_insert.json", MediaType.APPLICATION_JSON))
-              .build();
-
-      HttpResponse insertHttpHealthCheckResponse = HttpResponse.builder().statusCode(404).build();
-
-      HttpHealthCheckApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, create, insertHttpHealthCheckResponse).httpHeathChecks();
-
-      HttpHealthCheckCreationOptions options = new HttpHealthCheckCreationOptions().timeoutSec(0).unhealthyThreshold(0);
-      
-      api.insert("http-health-check", options);
    }
 
    public void testDeleteHttpHealthCheckResponseIs2xx() {
@@ -193,28 +171,6 @@ public class HttpHealthCheckApiExpectTest extends BaseGoogleComputeEngineExpectT
        assertEquals(api.patch(healthCheckName, options), new ParseGlobalOperationTest().expected());
    }
 
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testPatchHttpHealthChecksResponseIs4xx(){
-      String healthCheckName = "http-health-check";
-      HttpRequest patch = HttpRequest
-            .builder()
-            .method("PATCH")
-            .endpoint(BASE_URL + "/party/global/httpHealthChecks/" + healthCheckName)
-            .addHeader("Accept", "application/json")
-            .addHeader("Authorization", "Bearer " + TOKEN)
-            .payload(payloadFromResourceWithContentType("/httphealthcheck_insert.json", MediaType.APPLICATION_JSON))
-            .build();
-
-       HttpResponse insertHttpHealthCheckResponse = HttpResponse.builder().statusCode(404).build();
-   
-       HttpHealthCheckApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-               TOKEN_RESPONSE, patch,
-               insertHttpHealthCheckResponse).httpHeathChecks();
-       HttpHealthCheckCreationOptions options = new HttpHealthCheckCreationOptions().timeoutSec(0).unhealthyThreshold(0);
-       
-       api.patch(healthCheckName, options);
- }
-
    public void testUpdateHttpHealthChecksResponseIs2xx() {
       String healthCheckName = "http-health-check";
       HttpRequest patch = HttpRequest
@@ -235,26 +191,4 @@ public class HttpHealthCheckApiExpectTest extends BaseGoogleComputeEngineExpectT
        HttpHealthCheckCreationOptions options = new HttpHealthCheckCreationOptions().timeoutSec(0).unhealthyThreshold(0);
        assertEquals(api.update(healthCheckName, options), new ParseGlobalOperationTest().expected());
    }
-
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testUpdateHttpHealthChecksResponseIs4xx() {
-      String healthCheckName = "http-health-check";
-      HttpRequest patch = HttpRequest
-            .builder()
-            .method("PUT")
-            .endpoint(BASE_URL + "/party/global/httpHealthChecks/" + healthCheckName)
-            .addHeader("Accept", "application/json")
-            .addHeader("Authorization", "Bearer " + TOKEN)
-            .payload(payloadFromResourceWithContentType("/httphealthcheck_insert.json", MediaType.APPLICATION_JSON))
-            .build();
-
-       HttpResponse insertHttpHealthCheckResponse = HttpResponse.builder().statusCode(404).build();
-
-       HttpHealthCheckApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-               TOKEN_RESPONSE, patch,
-               insertHttpHealthCheckResponse).httpHeathChecks();
-       HttpHealthCheckCreationOptions options = new HttpHealthCheckCreationOptions().timeoutSec(0).unhealthyThreshold(0);
-       api.update(healthCheckName, options);
-   }
-
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiExpectTest.java
@@ -27,7 +27,6 @@ import org.jclouds.googlecomputeengine.parse.ParseImageTest;
 import org.jclouds.googlecomputeengine.parse.ParseOperationTest;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
-import org.jclouds.rest.ResourceNotFoundException;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "ImageApiExpectTest")
@@ -181,24 +180,5 @@ public class ImageApiExpectTest extends BaseGoogleComputeEngineExpectTest<Google
 
       assertEquals(imageApi.createFromDisk("my-image", BASE_URL + "/party/zones/us-central1-a/disks/mydisk"),
             new ParseOperationTest().expected());
-   }
-
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testCreateImageFromPdResponseIs4xx() {
-      HttpRequest createImage = HttpRequest
-            .builder()
-            .method("POST")
-            .endpoint(BASE_URL + "/party/global/images")
-            .addHeader("Accept", "application/json")
-            .addHeader("Authorization", "Bearer " + TOKEN)
-            .payload(payloadFromResource("/image_insert_from_pd.json"))
-            .build();
-
-      HttpResponse createImageResponse = HttpResponse.builder().statusCode(404).build();
-
-      ImageApi imageApi = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, createImage, createImageResponse).images();
-
-      imageApi.createFromDisk("my-image", BASE_URL + "/party/zones/us-central1-a/disks/mydisk");
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiExpectTest.java
@@ -21,6 +21,7 @@ import static org.jclouds.googlecomputeengine.features.ProjectApiExpectTest.GET_
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -28,17 +29,15 @@ import java.util.Arrays;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
+import org.jclouds.googlecomputeengine.domain.AttachDisk;
 import org.jclouds.googlecomputeengine.domain.Metadata;
 import org.jclouds.googlecomputeengine.domain.NewInstance;
-import org.jclouds.googlecomputeengine.domain.AttachDisk;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineExpectTest;
-import org.jclouds.googlecomputeengine.parse.ParseInstanceListTest;
 import org.jclouds.googlecomputeengine.parse.ParseInstanceSerialOutputTest;
 import org.jclouds.googlecomputeengine.parse.ParseInstanceTest;
 import org.jclouds.googlecomputeengine.parse.ParseZoneOperationTest;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
-import org.jclouds.rest.ResourceNotFoundException;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -197,12 +196,11 @@ public class InstanceApiExpectTest extends BaseGoogleComputeEngineExpectTest<Goo
    }
 
    public void list() {
-
       InstanceApi api = requestsSendResponses(
               requestForScopes(COMPUTE_READONLY_SCOPE), TOKEN_RESPONSE,
               LIST_INSTANCES_REQUEST, LIST_INSTANCES_RESPONSE).instancesInZone("us-central1-a");
 
-      assertEquals(api.list().next(), new ParseInstanceListTest().expected());
+      assertTrue(api.list().hasNext());
    }
 
    public void listEmpty() {
@@ -235,25 +233,6 @@ public class InstanceApiExpectTest extends BaseGoogleComputeEngineExpectTest<Goo
               new ParseZoneOperationTest().expected());
    }
 
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testSetInstanceMetadataResponseIs4xx() {
-      HttpRequest setMetadata = HttpRequest
-              .builder()
-              .method("POST")
-              .endpoint(BASE_URL + "/party/zones/us-central1-a/instances/test-1/setMetadata")
-              .addHeader("Accept", "application/json")
-              .addHeader("Authorization", "Bearer " + TOKEN)
-              .payload(payloadFromResourceWithContentType("/instance_set_metadata.json", MediaType.APPLICATION_JSON))
-              .build();
-
-      HttpResponse setMetadataResponse = HttpResponse.builder().statusCode(404).build();
-
-      InstanceApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, setMetadata, setMetadataResponse).instancesInZone("us-central1-a");
-
-      api.setMetadata("test-1", Metadata.create("efgh").put("foo", "bar"));
-   }
-
    public void testSetInstanceTagsResponseIs2xx() {
       HttpRequest setTags = HttpRequest
               .builder()
@@ -274,25 +253,6 @@ public class InstanceApiExpectTest extends BaseGoogleComputeEngineExpectTest<Goo
               new ParseZoneOperationTest().expected());
    }
 
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testSetInstanceTagsResponseIs4xx() {
-      HttpRequest setTags = HttpRequest
-              .builder()
-              .method("POST")
-              .endpoint(BASE_URL + "/party/zones/us-central1-a/instances/test-1/setTags")
-              .addHeader("Accept", "application/json")
-              .addHeader("Authorization", "Bearer " + TOKEN)
-              .payload(payloadFromResourceWithContentType("/instance_set_tags.json", MediaType.APPLICATION_JSON))
-              .build();
-
-      HttpResponse setTagsResponse = HttpResponse.builder().statusCode(404).build();
-
-      InstanceApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, setTags, setTagsResponse).instancesInZone("us-central1-a");
-
-      api.setTags("test-1", ImmutableList.of("foo", "bar"), "efgh");
-   }
-
    public void testResetInstanceResponseIs2xx() {
       HttpRequest reset = HttpRequest
               .builder()
@@ -309,23 +269,6 @@ public class InstanceApiExpectTest extends BaseGoogleComputeEngineExpectTest<Goo
 
       assertEquals(api.reset("test-1"),
               new ParseZoneOperationTest().expected());
-   }
-
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testResetInstanceResponseIs4xx() {
-      HttpRequest reset = HttpRequest
-              .builder()
-              .method("POST")
-              .endpoint(BASE_URL + "/party/zones/us-central1-a/instances/test-1/reset")
-              .addHeader("Accept", "application/json")
-              .addHeader("Authorization", "Bearer " + TOKEN).build();
-
-      HttpResponse resetResponse = HttpResponse.builder().statusCode(404).build();
-
-      InstanceApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, reset, resetResponse).instancesInZone("us-central1-a");
-
-      api.reset("test-1");
    }
 
    public void testAttachDiskResponseIs2xx() {
@@ -355,27 +298,6 @@ public class InstanceApiExpectTest extends BaseGoogleComputeEngineExpectTest<Goo
               new ParseZoneOperationTest().expected());
    }
 
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testAttachDiskResponseIs4xx() {
-      HttpRequest attach = HttpRequest
-              .builder()
-              .method("POST")
-              .endpoint(BASE_URL + "/party/zones/us-central1-a/instances/test-1/attachDisk")
-              .addHeader("Accept", "application/json")
-              .addHeader("Authorization", "Bearer " + TOKEN)
-              .payload(payloadFromResourceWithContentType("/instance_attach_disk.json", MediaType.APPLICATION_JSON))
-              .build();
-
-      HttpResponse attachResponse = HttpResponse.builder().statusCode(404).build();
-
-      InstanceApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, attach, attachResponse).instancesInZone("us-central1-a");
-
-      api.attachDisk("test-1", AttachDisk.create(AttachDisk.Type.PERSISTENT, AttachDisk.Mode.READ_ONLY,
-                                                        URI.create(BASE_URL + "/party/zones/us-central1-a/disks/testimage1"),
-                                                        null, false, null, true));
-   }
-
    public void testDetachDiskResponseIs2xx() {
       HttpRequest detach = HttpRequest
               .builder()
@@ -394,45 +316,6 @@ public class InstanceApiExpectTest extends BaseGoogleComputeEngineExpectTest<Goo
       assertEquals(api.detachDisk("test-1", "test-disk-1"),
               new ParseZoneOperationTest().expected());
    }
-
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testDetachDiskResponseIs4xx() {
-      HttpRequest detach = HttpRequest
-              .builder()
-              .method("POST")
-              .endpoint(BASE_URL + "/party/zones/us-central1-a/instances/test-1/detachDisk?deviceName=test-disk-1")
-              .addHeader("Accept", "application/json")
-              .addHeader("Authorization", "Bearer " + TOKEN)
-              .build();
-
-      HttpResponse detachResponse = HttpResponse.builder().statusCode(404).build();
-
-      InstanceApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, detach, detachResponse).instancesInZone("us-central1-a");
-
-      api.detachDisk("test-1", "test-disk-1");
-   }
-
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testSetDiskAutoDeleteResponseIs4xx() {
-      HttpRequest setTrue = HttpRequest
-            .builder()
-            .method("POST")
-            .endpoint("https://www.googleapis" +
-                    ".com/compute/v1/projects/party/zones/us-central1-a/instances/test-1/setDiskAutoDelete" +
-                    "?deviceName=test-disk-1&autoDelete=true")
-            .addHeader("Accept", "application/json")
-            .addHeader("Authorization", "Bearer " + TOKEN)
-            .build();
-
-      HttpResponse setTrueResponse = HttpResponse.builder().statusCode(404).build();
-
-      InstanceApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, setTrue, setTrueResponse).instancesInZone("us-central1-a");
-
-      api.setDiskAutoDelete("test-1", "test-disk-1", true);
-   }
-
 }
 
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/TargetPoolApiExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/TargetPoolApiExpectTest.java
@@ -33,7 +33,6 @@ import org.jclouds.googlecomputeengine.parse.ParseTargetPoolListTest;
 import org.jclouds.googlecomputeengine.parse.ParseTargetPoolTest;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
-import org.jclouds.rest.ResourceNotFoundException;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -174,17 +173,6 @@ public class TargetPoolApiExpectTest extends BaseGoogleComputeEngineExpectTest<G
       assertEquals(api.addInstance("test", INSTANCES),
               new ParseRegionOperationTest().expected());
    }
-
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testAddInstanceResponseIs4xx() throws Exception {
-      HttpRequest addInstance = makeGenericRequest("POST", "addInstance", "/targetpool_addinstance.json");
-      HttpResponse response = HttpResponse.builder().statusCode(404).build();
-
-      TargetPoolApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, addInstance, response).targetPoolsInRegion("us-central1");
-
-      api.addInstance("test", INSTANCES);
-   }
    
    public void testRemoveInstanceResponseIs2xx(){
       HttpRequest removeInstance = makeGenericRequest("POST", "removeInstance", "/targetpool_addinstance.json");
@@ -199,17 +187,6 @@ public class TargetPoolApiExpectTest extends BaseGoogleComputeEngineExpectTest<G
             new ParseRegionOperationTest().expected());
    }
    
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testRemoveInstanceResponseIs4xx() throws Exception {
-      HttpRequest removeInstance = makeGenericRequest("POST", "removeInstance", "/targetpool_addinstance.json");
-      HttpResponse response = HttpResponse.builder().statusCode(404).build();
-
-      TargetPoolApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, removeInstance, response).targetPoolsInRegion("us-central1");
-
-      api.removeInstance("test", INSTANCES);
-   }
-   
    public void testAddHealthCheckResponseIs2xx(){
       HttpRequest addHealthCheck = makeGenericRequest("POST", "addHealthCheck", "/targetpool_changehealthcheck.json");
       
@@ -221,18 +198,7 @@ public class TargetPoolApiExpectTest extends BaseGoogleComputeEngineExpectTest<G
 
       assertEquals(api.addHealthCheck("test", HEALTH_CHECKS), new ParseRegionOperationTest().expected());
    }
-   
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testAddHealthCheckResponseIs4xx() throws Exception {
-      HttpRequest addHealthCheck = makeGenericRequest("POST", "addHealthCheck", "/targetpool_changehealthcheck.json");
-      HttpResponse response = HttpResponse.builder().statusCode(404).build();
 
-      TargetPoolApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, addHealthCheck, response).targetPoolsInRegion("us-central1");
-
-      api.addHealthCheck("test", HEALTH_CHECKS);
-   }
-   
    public void testRemoveHealthCheckResponseIs2xx(){
       HttpRequest removeHealthCheck = makeGenericRequest("POST", "removeHealthCheck", "/targetpool_changehealthcheck.json");
       
@@ -244,18 +210,7 @@ public class TargetPoolApiExpectTest extends BaseGoogleComputeEngineExpectTest<G
 
       assertEquals(api.removeHealthCheck("test", HEALTH_CHECKS), new ParseRegionOperationTest().expected());
    }
-   
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testRemoveHealthCheckResponseIs4xx() throws Exception {
-      HttpRequest removeHealthCheck = makeGenericRequest("POST", "removeHealthCheck", "/targetpool_changehealthcheck.json");
-      HttpResponse response = HttpResponse.builder().statusCode(404).build();
 
-      TargetPoolApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-              TOKEN_RESPONSE, removeHealthCheck, response).targetPoolsInRegion("us-central1");
-
-      api.removeHealthCheck("test", HEALTH_CHECKS);
-   }
-   
    public void testSetBackupResponseIs2xx(){
       HttpRequest SetBackup = HttpRequest
             .builder()
@@ -293,25 +248,7 @@ public class TargetPoolApiExpectTest extends BaseGoogleComputeEngineExpectTest<G
       Float failoverRatio = Float.valueOf("0.5");
       assertEquals(api.setBackup("testpool", failoverRatio, TARGET_POOL), new ParseRegionOperationTest().expected());
    }
-   
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testSetBackupResponseIs4xx() throws Exception {
-      HttpRequest SetBackup = HttpRequest
-            .builder()
-            .method("POST")
-            .endpoint(BASE_URL + "/party/regions/us-central1/targetPools/testpool/setBackup")
-            .addHeader("Accept", "application/json")
-            .addHeader("Authorization", "Bearer " + TOKEN)
-            .payload(payloadFromResourceWithContentType("/targetpool_setbackup.json", MediaType.APPLICATION_JSON))
-            .build();
-      HttpResponse response = HttpResponse.builder().statusCode(404).build();
 
-      TargetPoolApi api = requestsSendResponses(requestForScopes(COMPUTE_SCOPE),
-            TOKEN_RESPONSE, SetBackup, response).targetPoolsInRegion("us-central1");
-
-      api.setBackup("testpool", TARGET_POOL);
-   }
-   
    public HttpRequest makeGenericRequest(String method, String endpoint, String requestPayloadFile){
       HttpRequest request = HttpRequest
             .builder()


### PR DESCRIPTION
When we add a `@Fallback`, we absolutely need a test to make sure we put the right one there. However, if we don't add a fallback annotation, we don't need to test error responses. When we do, we are only partially covering the universe of potential errors, and drowning out tests that are actually api-specific. Since it is less work anyway, I'm sure removing these will be welcome!
