### PR TITLE
Upgrade to OkHttp 2.1.0

### DIFF
--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiMockTest.java
@@ -92,7 +92,7 @@ public class BaseGoogleComputeEngineApiMockTest {
    }
 
    protected String url(String path) {
-      return "http://localhost:" + server.getPort() + path;
+      return server.getUrl(path).toString();
    }
 
    @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
Mockwebserver 2.1.0 does not bind the localhost address but the public address. That makes the test to fail if we hardcode the server URL to 'localhost'. The server.getUrl() method should be used instead.
