### PR TITLE
Bug fixes related to LiveTest failures

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/InstanceToNodeMetadata.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/InstanceToNodeMetadata.java
@@ -30,6 +30,7 @@ import org.jclouds.collect.Memoized;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadataBuilder;
+import org.jclouds.compute.domain.NodeMetadata.Status;
 import org.jclouds.compute.functions.GroupNamingConvention;
 import org.jclouds.domain.Location;
 import org.jclouds.googlecomputeengine.domain.Instance;
@@ -95,7 +96,7 @@ public final class InstanceToNodeMetadata implements Function<Instance, NodeMeta
              .location(zone)
              .imageId(bootImage != null ? bootImage.toString() : null)
              .hardware(hardwares.get().get(input.machineType()))
-             .status(toPortableNodeStatus.get(input.status()))
+             .status(input.status() != null ? toPortableNodeStatus.get(input.status()) : Status.UNRECOGNIZED)
              .tags(input.tags().items())
              .uri(input.selfLink())
              .userMetadata(input.metadata().asMap())

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/NewInstance.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/NewInstance.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jclouds.googlecomputeengine.domain.Instance.NetworkInterface.AccessConfig;
+import org.jclouds.googlecomputeengine.domain.Instance.NetworkInterface.AccessConfig.Type;
 import org.jclouds.googlecomputeengine.domain.Instance.Scheduling;
 import org.jclouds.googlecomputeengine.domain.Instance.ServiceAccount;
 import org.jclouds.javax.annotation.Nullable;
@@ -38,14 +39,14 @@ public abstract class NewInstance {
    abstract static class NetworkInterface {
       abstract URI network();
 
-      abstract List<AccessConfig.Type> accessConfigs();
+      abstract List<AccessConfig> accessConfigs();
 
       static NetworkInterface create(URI network) {
-         return create(network, Arrays.asList(AccessConfig.Type.ONE_TO_ONE_NAT));
+         return create(network, Arrays.asList(AccessConfig.create(null, Type.ONE_TO_ONE_NAT, null)));
       }
 
       @SerializedNames({ "network", "accessConfigs" })
-      static NetworkInterface create(URI network, List<AccessConfig.Type> accessConfigs) {
+      static NetworkInterface create(URI network, List<AccessConfig> accessConfigs) {
          return new AutoValue_NewInstance_NetworkInterface(network, accessConfigs);
       }
 

--- a/google-compute-engine/src/test/resources/instance_insert.json
+++ b/google-compute-engine/src/test/resources/instance_insert.json
@@ -5,7 +5,9 @@
     {
       "network": "https://www.googleapis.com/compute/v1/projects/party/global/networks/default",
       "accessConfigs": [
-        "ONE_TO_ONE_NAT"
+        {
+          "type": "ONE_TO_ONE_NAT"
+        }
       ]
     }
   ],

--- a/google-compute-engine/src/test/resources/instance_insert_2.json
+++ b/google-compute-engine/src/test/resources/instance_insert_2.json
@@ -5,7 +5,9 @@
     {
       "network": "https://www.googleapis.com/compute/v1/projects/party/networks/jclouds-test",
       "accessConfigs": [
-        "ONE_TO_ONE_NAT"
+        {
+          "type": "ONE_TO_ONE_NAT"
+        }
       ]
     }
   ],

--- a/google-compute-engine/src/test/resources/instance_insert_simple.json
+++ b/google-compute-engine/src/test/resources/instance_insert_simple.json
@@ -5,7 +5,9 @@
     {
       "network": "https://www.googleapis.com/compute/v1/projects/party/global/networks/default",
       "accessConfigs": [
-        "ONE_TO_ONE_NAT"
+        {
+          "type": "ONE_TO_ONE_NAT"
+        }
       ]
     }
   ],


### PR DESCRIPTION
Malformed Instance insert was leading to no external IP address. 

Live tests are still broken but this is a step in the right direction. 
