### PR TITLE
Fixed InstanceApiLiveTest, made Instance.status @Nullable

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Instance.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Instance.java
@@ -225,7 +225,7 @@ public abstract class Instance {
 
    public abstract URI machineType();
 
-   public abstract Status status();
+   @Nullable public abstract Status status();
 
    /** Human-readable explanation of the status. */
    @Nullable public abstract String statusMessage();

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
@@ -126,9 +126,14 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    @Test(groups = "live", dependsOnMethods = "testInsertInstance")
    public void testAddAccessConfig() {
+      Instance instance = api().get(INSTANCE_NAME);
+      assertNotNull(instance);
+      assertOperationDoneSuccessfully(api().deleteAccessConfigFromNic(INSTANCE_NAME,
+            instance.networkInterfaces().get(0).accessConfigs().get(0).name(), "nic0"));
+
       AccessConfig config = AccessConfig.create("test-config", Type.ONE_TO_ONE_NAT, null);
       assertOperationDoneSuccessfully(api().addAccessConfigToNic(INSTANCE_NAME, config, "nic0"));
-      Instance instance = api().get(INSTANCE_NAME);
+      instance = api().get(INSTANCE_NAME);
       assertNotNull(instance);
       assertEquals(instance.networkInterfaces().get(0).accessConfigs().get(0).name(), "test-config");
    }


### PR DESCRIPTION
Fixes bug in InstanceApiLiveTest. 

Also Instance Status is sometimes not returned when repeatedly calling instance get and the instance status is transitioning from one state to another. This was causing intermittent test failures. 