### PR TITLE
Split Auto dependencies

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -67,6 +67,11 @@
             <version>${jclouds.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
             <scope>provided</scope>

--- a/google-compute-engine/pom.xml
+++ b/google-compute-engine/pom.xml
@@ -68,6 +68,11 @@
             <version>${jclouds.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
Splitting the `auto-service` and `auto-value` dependencies allows us to control individual versions of these libraries.