### PR TITLE
JCLOUDS-808: Enables working with .json key files, adding GoogleComputeEngineCredenti...

### DIFF
--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceLiveTest.java
@@ -45,6 +45,7 @@ public class GoogleComputeEngineServiceLiveTest extends BaseComputeServiceLiveTe
    }
 
    @Override protected Properties setupProperties() {
+      TestProperties.setGoogleCredentialsFromJson(provider);
       return TestProperties.apply(provider, super.setupProperties());
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiLiveTest.java
@@ -68,6 +68,7 @@ public class BaseGoogleComputeEngineApiLiveTest extends BaseApiLiveTest<GoogleCo
    }
 
    @Override protected Properties setupProperties() {
+      TestProperties.setGoogleCredentialsFromJson(provider);
       return TestProperties.apply(provider, super.setupProperties());
    }
 

--- a/googlecloud/src/main/java/org/jclouds/googlecloud/GoogleCredentialsFromJson.java
+++ b/googlecloud/src/main/java/org/jclouds/googlecloud/GoogleCredentialsFromJson.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecloud;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.domain.Credentials;
+
+import com.google.common.base.Supplier;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/*
+ * Provides an easy way to pass in credentials using the json-key format.
+ * Just provide the path to the .json file and this extracts and sets identity
+ *  and credentials from the json.
+ */
+public class GoogleCredentialsFromJson implements Supplier<Credentials>{
+
+   private final String jsonKeyString;
+
+   public GoogleCredentialsFromJson(String jsonString){
+      checkNotNull(jsonString, "Google Credentials jsonString cannot be null");
+      jsonKeyString = jsonString;
+   }
+
+   /**
+    * Function for parsing JSON Key String from file downloaded from GCP developers console.
+    *
+    * @param jsonString - a String in JSON format containing service account credentials
+    *  as provided from the Google Developers Console
+    * @return Credentials object with Credentials.identity and Credentials.credential correctly set.
+    */
+   private static Credentials parseJsonKeyString(String jsonString) {
+      // Parse JsonFile to extract Service Account and PrivateKey.
+      final JsonObject json = new JsonParser().parse(jsonString).getAsJsonObject();
+      String client_email = json.get("client_email").toString().replace("\"", "");
+      // When reading the file it reads in \n in as
+      String private_key = json.get("private_key").toString().replace("\"", "").replace("\\n", "\n");
+
+      return new Credentials(client_email, // identity
+                             private_key); // credentials
+   }
+
+   @Override
+   public Credentials get() {
+      return parseJsonKeyString(jsonKeyString);
+   }
+}

--- a/googlecloud/src/test/java/org/jclouds/googlecloud/internal/TestProperties.java
+++ b/googlecloud/src/test/java/org/jclouds/googlecloud/internal/TestProperties.java
@@ -24,8 +24,11 @@ import static org.jclouds.oauth.v2.config.CredentialType.P12_PRIVATE_KEY_CREDENT
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Properties;
 
+import org.jclouds.domain.Credentials;
+import org.jclouds.googlecloud.GoogleCredentialsFromJson;
 import org.jclouds.oauth.v2.config.CredentialType;
 
 import com.google.common.base.Charsets;
@@ -78,6 +81,26 @@ public final class TestProperties {
       }
       overrides.setProperty(key, credentialFromFile);
       return credentialFromFile;
+   }
+
+   /*
+    * Provides an easy way to pass in credentials using the json-key format.
+    * Just provide the path to the .json file as the system property test.google-cloud.json-key
+    * and this extracts and sets identity  and credentials from the json.
+    */
+   public static void setGoogleCredentialsFromJson(String provider) {
+      String key = "test.google-cloud.json-key";
+      if (System.getProperties().containsKey(key)) {
+         String val = System.getProperty(key);
+         try {
+            String fileContents = Files.toString(new File(val), Charset.defaultCharset());
+            Credentials creds = new GoogleCredentialsFromJson(fileContents).get();
+            System.setProperty("test." + provider + ".identity", creds.identity);
+            System.setProperty("test." + provider + ".credential", creds.credential);
+         } catch (IOException e) {
+            throw propagate(e);
+         }
+      }
    }
 
    private TestProperties() {


### PR DESCRIPTION
...alSupplier

This is WIP branch with an idea of how to move towards using JSON key files instead of PEM keys.

Something along the lines of the following:
```
ComputeServiceContext context = ContextBuilder.newBuilder("google-compute-engine")
                         .credentialsSupplier(new GoogleComputeEngineCredentialSupplier("/path/to/file.json))
                         .buildView(ComputeServiceContext.class);
```

This also (optionally) changes how the live tests are run. 
If you set the parameter `test.google-compute-engine.json-key` to /path/to/file.json it will populate 
`test.google-compute-engine.identity` and `test.google-compute-engine.credential` from the file. 

This will also require documentation updates ect.

@nacx WDYT?

