### PR TITLE
Updated BackendServiceOptions to AutoValue + Builder

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/binders/ForwardingRuleCreationBinder.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/binders/ForwardingRuleCreationBinder.java
@@ -45,8 +45,8 @@ public class ForwardingRuleCreationBinder extends BindToJsonPayload {
 
       /**
        * Values used to bind ForwardingRuleOptions to json request.
-       * Note: Two break convention of starting with lower case letters due to 
-       *       attributes on GCE starting with upper case letters. 
+       * Note: Two break convention of starting with lower case letters due to
+       *       attributes on GCE starting with upper case letters.
        */
       @SuppressWarnings("unused")
       private String name;
@@ -63,11 +63,11 @@ public class ForwardingRuleCreationBinder extends BindToJsonPayload {
 
       private ForwardingRuleCreationBinderHelper(String name, ForwardingRuleCreationOptions forwardingRuleCreationOptions){
          this.name = name;
-         this.description = forwardingRuleCreationOptions.getDescription();
-         this.IPAddress = forwardingRuleCreationOptions.getIPAddress();
-         this.IPProtocol = forwardingRuleCreationOptions.getIPProtocol();
-         this.portRange = forwardingRuleCreationOptions.getPortRange();
-         this.target = forwardingRuleCreationOptions.getTarget();
+         this.description = forwardingRuleCreationOptions.description();
+         this.IPAddress = forwardingRuleCreationOptions.ipAddress();
+         this.IPProtocol = forwardingRuleCreationOptions.ipProtocol();
+         this.portRange = forwardingRuleCreationOptions.portRange();
+         this.target = forwardingRuleCreationOptions.target();
       }
    }
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/BackendServiceOptions.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/BackendServiceOptions.java
@@ -21,154 +21,135 @@ import java.util.List;
 
 import org.jclouds.googlecomputeengine.domain.BackendService.Backend;
 import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
 
-public class BackendServiceOptions {
+import com.google.auto.value.AutoValue;
 
-   private String name;
-   @Nullable private String description;
-   private List<URI> healthChecks;
-   private List<Backend> backends;
-   private Integer timeoutSec;
-   private Integer port;
-   private String protocol;
-   private String fingerprint;
-   private String portName;
+@AutoValue
+public abstract class BackendServiceOptions {
 
-   /**
-    * Name of the BackendService resource.
-    * @return name, provided by the client.
-    */
-   public String getName(){
-      return name;
+   @Nullable public abstract String name();
+   @Nullable public abstract String description();
+   @Nullable public abstract List<URI> healthChecks();
+   @Nullable public abstract List<Backend> backends();
+   @Nullable public abstract Integer timeoutSec();
+   @Nullable public abstract Integer port();
+   @Nullable public abstract String protocol();
+   @Nullable public abstract String fingerprint();
+   @Nullable public abstract String portName();
+
+   @SerializedNames({"name", "description", "healthChecks", "backends", "timeoutSec",
+      "port", "protocol", "fingerprint", "portName"})
+   static BackendServiceOptions create(String name, String description, List<URI> healthChecks,
+         List<Backend> backends, Integer timeoutSec, Integer port, String protocol, String fingerprint, String portName){
+      return new AutoValue_BackendServiceOptions(name, description, healthChecks,
+            backends, timeoutSec, port, protocol, fingerprint, portName);
    }
 
-   /**
-    * @see BackendServiceOptions#getName()
-    */
-   public BackendServiceOptions name(String name) {
-      this.name = name;
-      return this;
+   BackendServiceOptions(){
    }
 
-   /**
-    * An optional textual description of the BackendService.
-    * @return description, provided by the client.
-    */
-   public String getDescription(){
-      return description;
-   }
+   public static class Builder {
 
-   /**
-    * @see BackendServiceOptions#getDescription()
-    */
-   public BackendServiceOptions description(String description) {
-      this.description = description;
-      return this;
-   }
+      private String name;
+      private String description;
+      private List<URI> healthChecks;
+      private List<Backend> backends;
+      private Integer timeoutSec;
+      private Integer port;
+      private String protocol;
+      private String fingerprint;
+      private String portName;
 
-   /**
-    * The list of {@link HttpHealthCheck#selfLink Links} to the HttpHealthCheck resource for health checking this BackendService.
-    * Currently at most one health check can be specified, and a health check is required.
-    */
-   public List<URI> getHealthChecks() {
-      return healthChecks;
-   }
+      /**
+       * @param name, provided by the client.
+       * @param healthChecks The list of {@link HttpHealthCheck#selfLink Links} to the HttpHealthCheck
+       * resource for health checking this BackendService.
+       * Currently at most one health check can be specified, and a health check is required.
+       */
+      public Builder(String name, List<URI> healthChecks){
+         this.name = name;
+         this.healthChecks = healthChecks;
+      }
 
-   /**
-    * @see BackendServiceOptions#getHealthChecks()
-    */
-   public BackendServiceOptions healthChecks(List<URI> healthChecks) {
-      this.healthChecks = healthChecks;
-      return this;
-   }
+      /**
+       * Empty builder for use when patching or updating and existing BackendService
+       * Otherwise use the other {@link #Builder(String, List) builder}
+       */
+      public Builder(){
+      }
 
-   /**
-    * The list of backends that serve this BackendService.
-    */
-   public List<Backend> getBackends() {
-      return backends;
-   }
+      /**
+       * An optional textual description of the BackendService.
+       */
+      public Builder description(String description){
+         this.description =  description;
+         return this;
+      }
 
-   /**
-    * @see BackendServiceOptions#getBackends()
-    */
-   public BackendServiceOptions backends(List<Backend> backends){
-      this.backends = backends;
-      return this;
-   }
+      /**
+       *  HealthChecks - The list of {@link HttpHealthCheck#selfLink Links} to the HttpHealthCheck
+       * resource for health checking this BackendService.
+       * Currently at most one health check can be specified, and a health check is required.
+       */
+      public Builder healthChecks(List<URI> healthChecks){
+         this.healthChecks =  healthChecks;
+         return this;
+      }
 
-   /**
-    * How many seconds to wait for the backend before considering it a failed request.
-    * Default is 30 seconds.
-    */
-   public Integer getTimeoutSec() {
-      return timeoutSec;
-   }
+      /**
+       * The list of backends that serve this BackendService.
+       */
+      public Builder backends(List<Backend> backends){
+         this.backends = backends;
+         return this;
+      }
 
-   /**
-    * @see BackendServiceOptions#getTimeoutSec()
-    */
-   public BackendServiceOptions timeoutSec(Integer timeoutSec) {
-      this.timeoutSec = timeoutSec;
-      return this;
-   }
+      /**
+       * How many seconds to wait for the backend before considering it a failed request.
+       * Default is 30 seconds.
+       */
+      public Builder timeoutSec(Integer timeoutSec) {
+         this.timeoutSec = timeoutSec;
+         return this;
+      }
 
-   /**
-    * The TCP port to connect on the backend.
-    * The default value is 80.
-    */
-   public Integer getPort() {
-      return port;
-   }
+      /**
+       * The TCP port to connect on the backend.
+       * The default value is 80.
+       */
+      public Builder port(Integer port) {
+         this.port = port;
+         return this;
+      }
 
-   /**
-    * @see BackendServiceOptions#getPort()
-    */
-   public BackendServiceOptions port(Integer port) {
-      this.port = port;
-      return this;
-   }
+      /**
+       * The  protocol for incoming requests.
+       */
+      public Builder protocol(String protocol) {
+         this.protocol = protocol;
+         return this;
+      }
 
+      /**
+       * Fingerprint of this resource. A hash of the contents stored in this object.
+       * This field is used in optimistic locking. This field will be ignored when
+       * inserting a BackendService. An up-to-date fingerprint must be provided in
+       * order to update the BackendService.
+       */
+      public Builder fingerprint(String fingerprint) {
+         this.fingerprint = fingerprint;
+         return this;
+      }
 
-   /**
-    * The  protocol for incoming requests.
-    */
-   public String getProtocol() {
-      return protocol;
-   }
+      public Builder portName(String portName) {
+         this.portName = portName;
+         return this;
+      }
 
-   /**
-    * @see BackendServiceOptions#getProtocol()
-    */
-   public BackendServiceOptions protocol(String protocol) {
-      this.protocol = protocol;
-      return this;
-   }
-
-   /**
-    * Fingerprint of this resource. A hash of the contents stored in this object.
-    * This field is used in optimistic locking. This field will be ignored when
-    * inserting a BackendService. An up-to-date fingerprint must be provided in
-    * order to update the BackendService.
-    */
-   public String getFingerprint() {
-      return fingerprint;
-   }
-
-   /**
-    * @see BackendServiceOptions#getFingerprint()
-    */
-   public BackendServiceOptions fingerprint(String fingerprint) {
-      this.fingerprint = fingerprint;
-      return this;
-   }
-
-   public String getPortName() {
-      return portName;
-   }
-
-   public BackendServiceOptions portName(String portName) {
-      this.portName = portName;
-      return this;
+      public BackendServiceOptions build(){
+         return create(name, description, healthChecks,
+               backends, timeoutSec, port, protocol, fingerprint, portName);
+      }
    }
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/DeprecateOptions.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/DeprecateOptions.java
@@ -18,104 +18,96 @@ package org.jclouds.googlecomputeengine.options;
 
 import java.net.URI;
 import java.util.Date;
+
 import org.jclouds.googlecomputeengine.domain.Deprecated.State;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
 
 /**
  * Options to set the deprecation status of a resource. Currently only for images.
  *
  * @see <a href="https://developers.google.com/compute/docs/reference/latest/images/deprecate" />
  */
-public class DeprecateOptions {
+@AutoValue
+public abstract class DeprecateOptions {
 
-   private State state;
-   private URI replacement;
-   private Date deprecated;
-   private Date obsolete;
-   private Date deleted;
+   @Nullable public abstract State state();
+   @Nullable public abstract URI replacement();
+   @Nullable public abstract Date deprecated();
+   @Nullable public abstract Date obsolete();
+   @Nullable public abstract Date deleted();
 
-   /**
-    * The new deprecation state.
-    *
-    * @return the new deprecation state.
-    */
-   public State getState() {
-      return state;
+   @SerializedNames({"state", "replacement", "deprecated", "obsolete", "deleted"})
+   static DeprecateOptions create(State state, URI replacement, Date deprecated,
+         Date obsolete, Date deleted){
+      return new AutoValue_DeprecateOptions(state, replacement, deprecated, obsolete, deleted);
    }
 
-   /**
-    * Optional URL for replacement of deprecated resource.
-    *
-    * @return the URL
-    */
-   public URI getReplacement() {
-      return replacement;
+   DeprecateOptions(){
    }
 
-   /**
-    * Optional RFC3339 timestamp for when the deprecation state was changed to DEPRECATED.
-    *
-    * @return the timestamp
-    */
-   public Date getDeprecated() {
-      return deprecated;
-   }
+   public static class Builder {
+      private State state;
+      private URI replacement;
+      private Date deprecated;
+      private Date obsolete;
+      private Date deleted;
 
-   /**
-    * Optional RFC3339 timestamp for when the deprecation state was changed to OBSOLETE.
-    *
-    * @return the timestamp
-    */
-   public Date getObsolete() {
-      return obsolete;
-   }
+      /**
+       * The new deprecation state.
+       *
+       * @return the new deprecation state.
+       */
+      public Builder state(State state) {
+         this.state = state;
+         return this;
+      }
 
-   /**
-    * Optional RFC3339 timestamp for when the deprecation state was changed to DELETED.
-    *
-    * @return the timestamp
-    */
-   public Date getDeleted() {
-      return deleted;
-   }
+      /**
+       * Optional URL for replacement of deprecated resource.
+       *
+       * @return the URL
+       */
+      public Builder replacement(URI replacement) {
+         this.replacement = replacement;
+         return this;
+      }
 
-   /**
-    * @see DeprecateOptions#getState()
-    */
-   public DeprecateOptions state(State state) {
-      this.state = state;
-      return this;
-   }
+      /**
+       * Optional RFC3339 timestamp for when the deprecation state was changed to DEPRECATED.
+       *
+       * @return the timestamp
+       */
+      public Builder deprecated(Date deprecated) {
+         this.deprecated = deprecated;
+         return this;
+      }
 
-   /**
-    * @see DeprecateOptions#getReplacement()
-    */
-   public DeprecateOptions replacement(URI replacement) {
-      this.replacement = replacement;
-      return this;
-   }
+      /**
+       * Optional RFC3339 timestamp for when the deprecation state was changed to OBSOLETE.
+       *
+       * @return the timestamp
+       */
+      public Builder obsolete(Date obsolete) {
+         this.obsolete = obsolete;
+         return this;
+      }
 
-   /**
-    * @see DeprecateOptions#getDeprecated()
-    */
-   public DeprecateOptions deprecated(Date deprecated) {
-      this.deprecated = deprecated;
-      return this;
-   }
+      /**
+       * Optional RFC3339 timestamp for when the deprecation state was changed to DELETED.
+       *
+       * @return the timestamp
+       */
+      public Builder deleted(Date deleted) {
+         this.deleted = deleted;
+         return this;
+      }
 
-   /**
-    * @see DeprecateOptions#getObsolete()
-    */
-   public DeprecateOptions obsolete(Date obsolete) {
-      this.obsolete = obsolete;
-      return this;
+      public DeprecateOptions build(){
+         return create(state, replacement, deprecated,
+               obsolete, deleted);
+      }
    }
-
-   /**
-    * @see DeprecateOptions#getDeleted()
-    */
-   public DeprecateOptions deleted(Date deleted) {
-      this.deleted = deleted;
-      return this;
-   }
-
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/DiskCreationOptions.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/DiskCreationOptions.java
@@ -18,79 +18,77 @@ package org.jclouds.googlecomputeengine.options;
 
 import java.net.URI;
 
-public final class DiskCreationOptions {
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
 
-   private URI type;
-   private Integer sizeGb;
-   private URI sourceSnapshot;
-   private String description;
+import com.google.auto.value.AutoValue;
 
+@AutoValue
+public abstract class DiskCreationOptions {
 
-   /**
-    * The disk type, fully qualified URL for the disk type.
-    *
-    * @return the disk type
-    */
-   public URI type() {
-      return type;
+   @Nullable public abstract URI type();
+   @Nullable public abstract Integer sizeGb();
+   @Nullable public abstract URI sourceSnapshot();
+   @Nullable public abstract String description();
+
+   @SerializedNames({"type", "sizeGb", "sourceSnapshot", "description"})
+   static DiskCreationOptions create(URI type, Integer sizeGb, URI sourceSnapshot,
+         String description){
+      return new AutoValue_DiskCreationOptions(type, sizeGb, sourceSnapshot, description);
    }
 
-   /**
-    * Size of the persistent disk, specified in GB.
-    * You can also specify this when creating a persistent disk
-    * using the sourceImage or sourceSnapshot parameter.
-    */
-   public Integer sizeGb() {
-      return sizeGb;
+   DiskCreationOptions(){
    }
 
-   /**
-    * The source snapshot
-    *
-    * @return sourceSnapshot, fully qualified URL for the snapshot to be copied.
-    */
-   public URI sourceSnapshot() {
-      return sourceSnapshot;
-   }
+   public static class Builder {
 
-   /**
-    * The description
-    *
-    * @return description, An optional textual description of the resource.
-    */
-   public String description() {
-      return description;
-   }
+      private URI type;
+      private Integer sizeGb;
+      private URI sourceSnapshot;
+      private String description;
 
-   /**
-    * @see DiskCreationOptions#type()
-    */
-   public DiskCreationOptions type(URI type) {
-      this.type = type;
-      return this;
-   }
+      /**
+       * The disk type, fully qualified URL for the disk type.
+       *
+       * @return the disk type
+       */
+      public Builder type(URI type) {
+         this.type = type;
+         return this;
+      }
 
-   /**
-    * @see DiskCreationOptions#sizeGb()
-    */
-   public DiskCreationOptions sizeGb(Integer sizeGb) {
-      this.sizeGb = sizeGb;
-      return this;
-   }
+      /**
+       * Size of the persistent disk, specified in GB.
+       * You can also specify this when creating a persistent disk
+       * using the sourceImage or sourceSnapshot parameter.
+       */
+      public Builder sizeGb(Integer sizeGb) {
+         this.sizeGb = sizeGb;
+         return this;
+      }
 
-   /**
-    * @see DiskCreationOptions#sourceSnapshot()
-    */
-   public DiskCreationOptions sourceSnapshot(URI sourceSnapshot) {
-      this.sourceSnapshot = sourceSnapshot;
-      return this;
-   }
+      /**
+       * The source snapshot
+       *
+       * @return sourceSnapshot, fully qualified URL for the snapshot to be copied.
+       */
+      public Builder sourceSnapshot(URI sourceSnapshot) {
+         this.sourceSnapshot = sourceSnapshot;
+         return this;
+      }
 
-   /**
-    * @see DiskCreationOptions#description()
-    */
-   public DiskCreationOptions description(String description) {
-      this.description = description;
-      return this;
+      /**
+       * The description
+       *
+       * @return description, An optional textual description of the resource.
+       */
+      public Builder description(String description) {
+         this.description = description;
+         return this;
+      }
+
+      public DiskCreationOptions build(){
+         return create(type, sizeGb, sourceSnapshot, description);
+      }
    }
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/ForwardingRuleCreationOptions.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/ForwardingRuleCreationOptions.java
@@ -19,98 +19,91 @@ package org.jclouds.googlecomputeengine.options;
 import java.net.URI;
 
 import org.jclouds.googlecomputeengine.domain.ForwardingRule;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
 
 /**
  * Options for creating a Forwarding Rule
  */
-public class ForwardingRuleCreationOptions{
+@AutoValue
+public abstract class ForwardingRuleCreationOptions{
 
-   private String description;
-   private String ipAddress;
-   private ForwardingRule.IPProtocol ipProtocol;
-   private String portRange;
-   private URI target;
-   
-   /**
-    * An optional textual description of the TargetPool.
-    * @return description, provided by the client.
-    */
-   public String getDescription(){
-      return description;
+   @Nullable public abstract String description();
+   @Nullable public abstract String ipAddress();
+   @Nullable public abstract ForwardingRule.IPProtocol ipProtocol();
+   @Nullable public abstract String portRange();
+   @Nullable public abstract URI target();
+
+
+   @SerializedNames({"description", "ipAddress", "ipProtocol", "portRange", "target"})
+   static ForwardingRuleCreationOptions create(
+         String description, String ipAddress, ForwardingRule.IPProtocol ipProtocol,
+         String portRange, URI target){
+      return new AutoValue_ForwardingRuleCreationOptions(description, ipAddress, ipProtocol, portRange, target);
    }
 
-   /**
-    * The external IP address that this forwarding rule is serving on behalf of
-    * @return ipAddress
-    */
-   public String getIPAddress(){
-      return ipAddress;
+   ForwardingRuleCreationOptions(){
    }
 
-   /**
-    * The IP protocol to which this rule applies
-    * @return ipProtocol
-    */
-   public ForwardingRule.IPProtocol getIPProtocol(){
-      return ipProtocol;
-   }
+   public static class Builder {
 
-   /**
-    * If IPProtocol is TCP or UDP, packets addressed to ports in the specified range 
-    * will be forwarded to backend. By default, this is empty and all ports are allowed.
-    * @return portRange
-    */
-   public String getPortRange(){
-      return portRange;
-   }
+      private String description;
+      private String ipAddress;
+      private ForwardingRule.IPProtocol ipProtocol;
+      private String portRange;
+      private URI target;
 
-   /**
-    * The URL of the target resource to receive the matched traffic.
-    * The target resource must live in the same region as this forwarding rule.
-    * @return target
-    */
-   public URI getTarget(){
-      return target;
-   }
+      /**
+       * An optional textual description of the TargetPool.
+       * @return description, provided by the client.
+       */
+      public Builder description(String description){
+         this.description = description;
+         return this;
+      }
 
-   /**
-    * @see ForwardingRuleCreationOptions#getDescription()
-    */
-   public ForwardingRuleCreationOptions description(String description){
-      this.description = description;
-      return this;
-   }
+      /**
+       * The external IP address that this forwarding rule is serving on behalf of
+       * @return ipAddress
+       */
+      public Builder ipAddress(String ipAddress){
+         this.ipAddress = ipAddress;
+         return this;
+      }
 
-   /**
-    * @see ForwardingRuleCreationOptions#getIPAddress()
-    */
-   public ForwardingRuleCreationOptions ipAddress(String ipAddress){
-      this.ipAddress = ipAddress;
-      return this;
-   }
+      /**
+       * The IP protocol to which this rule applies
+       * @return ipProtocol
+       */
+      public Builder ipProtocol(ForwardingRule.IPProtocol ipProtocol){
+         this.ipProtocol = ipProtocol;
+         return this;
+      }
 
-   /**
-    * @see ForwardingRuleCreationOptions#getIPProtocol()
-    */
-   public ForwardingRuleCreationOptions ipProtocol(ForwardingRule.IPProtocol ipProtocol){
-      this.ipProtocol = ipProtocol;
-      return this;
-   }
+      /**
+       * If IPProtocol is TCP or UDP, packets addressed to ports in the specified range
+       * will be forwarded to backend. By default, this is empty and all ports are allowed.
+       * @return portRange
+       */
+      public Builder portRange(String portRange){
+         this.portRange = portRange;
+         return this;
+      }
 
-   /**
-    * @see ForwardingRuleCreationOptions#getPortRange()
-    */
-   public ForwardingRuleCreationOptions portRange(String portRange){
-      this.portRange = portRange;
-      return this;
-   }
+      /**
+       * The URL of the target resource to receive the matched traffic.
+       * The target resource must live in the same region as this forwarding rule.
+       * @return target
+       */
+      public Builder target(URI target){
+         this.target = target;
+         return this;
+      }
 
-   /**
-    * @see ForwardingRuleCreationOptions#getTarget()
-    */
-   public ForwardingRuleCreationOptions target(URI target){
-      this.target = target;
-      return this;
+      public ForwardingRuleCreationOptions build() {
+         return create(description, ipAddress, ipProtocol, portRange, target);
+      }
    }
-
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/ImageCreationOptions.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/options/ImageCreationOptions.java
@@ -42,7 +42,7 @@ public abstract class ImageCreationOptions {
       return new AutoValue_ImageCreationOptions(name, description, sourceType, rawDisk, deprecated, sourceDisk);
    }
 
-   public static class Builder{
+   public static class Builder {
       public String name;
       public String description;
       public String sourceType;

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/binders/DiskCreationBinderTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/binders/DiskCreationBinderTest.java
@@ -38,8 +38,8 @@ public class DiskCreationBinderTest extends BaseGoogleComputeEngineExpectTest<Ob
 
    @Test
    public void testMap() throws SecurityException, NoSuchMethodException {
-      DiskCreationOptions diskCreationOptions = new DiskCreationOptions()
-         .sourceSnapshot(URI.create(FAKE_SOURCE_SNAPSHOT)).sizeGb(15).description(null);
+      DiskCreationOptions diskCreationOptions = new DiskCreationOptions.Builder()
+         .sourceSnapshot(URI.create(FAKE_SOURCE_SNAPSHOT)).sizeGb(15).description(null).build();
 
       HttpRequest request = HttpRequest.builder().method("GET").endpoint("http://momma").build();
       Map<String, Object> postParams = ImmutableMap.of("name", "testName", "options", diskCreationOptions);

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/binders/ForwardingRuleCreationBinderTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/binders/ForwardingRuleCreationBinderTest.java
@@ -45,12 +45,13 @@ public class ForwardingRuleCreationBinderTest extends BaseGoogleComputeEngineExp
    @Test
    public void testMap() throws SecurityException, NoSuchMethodException {
       ForwardingRuleCreationBinder binder = new ForwardingRuleCreationBinder(json);
-      ForwardingRuleCreationOptions forwardingRuleCreationOptions = new ForwardingRuleCreationOptions()
+      ForwardingRuleCreationOptions forwardingRuleCreationOptions = new ForwardingRuleCreationOptions.Builder()
                                                                   .description(DESCRIPTION)
                                                                   .ipAddress(IP_ADDRESS)
                                                                   .ipProtocol(ForwardingRule.IPProtocol.SCTP)
                                                                   .portRange(PORT_RANGE)
-                                                                  .target(TARGET);
+                                                                  .target(TARGET)
+                                                                  .build();
 
       HttpRequest request = HttpRequest.builder().method("GET").endpoint("http://momma").build();
       Map<String, Object> postParams = ImmutableMap.of("name", "testForwardingRuleName", "options", forwardingRuleCreationOptions);

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/AggregatedListApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/AggregatedListApiLiveTest.java
@@ -52,7 +52,7 @@ public class AggregatedListApiLiveTest extends BaseGoogleComputeEngineApiLiveTes
 
       List<MachineType> machineTypeAsList = pageIterator.next();
 
-      assertEquals(machineTypeAsList.size(), 9); // zone count!
+      assertEquals(machineTypeAsList.size(), 1);
    }
 
    public void addresses() {

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/BackendServiceApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/BackendServiceApiLiveTest.java
@@ -47,7 +47,8 @@ public class BackendServiceApiLiveTest extends BaseGoogleComputeEngineApiLiveTes
       assertOperationDoneSuccessfully(api.httpHeathChecks().insert(BACKEND_SERVICE_HEALTH_CHECK_NAME));
 
       List<URI> healthChecks = ImmutableList.of(getHealthCheckUrl(BACKEND_SERVICE_HEALTH_CHECK_NAME));
-      BackendServiceOptions b = new BackendServiceOptions().name(BACKEND_SERVICE_NAME).healthChecks(healthChecks);
+
+      BackendServiceOptions b = new BackendServiceOptions.Builder(BACKEND_SERVICE_NAME, healthChecks).build();
       assertOperationDoneSuccessfully(api().create(b));
    }
 
@@ -61,11 +62,10 @@ public class BackendServiceApiLiveTest extends BaseGoogleComputeEngineApiLiveTes
    @Test(groups = "live", dependsOnMethods = "testGetBackendService")
    public void testPatchBackendService() {
       String fingerprint = api().get(BACKEND_SERVICE_NAME).fingerprint();
-      BackendServiceOptions backendService = new BackendServiceOptions()
-              .name(BACKEND_SERVICE_NAME)
-              .healthChecks(ImmutableList.of(getHealthCheckUrl(BACKEND_SERVICE_HEALTH_CHECK_NAME)))
+      BackendServiceOptions backendService = new BackendServiceOptions.Builder(BACKEND_SERVICE_NAME, ImmutableList.of(getHealthCheckUrl(BACKEND_SERVICE_HEALTH_CHECK_NAME)))
               .timeoutSec(10)
-              .fingerprint(fingerprint);
+              .fingerprint(fingerprint)
+              .build();
 
       assertOperationDoneSuccessfully(api().update(BACKEND_SERVICE_NAME, backendService));
       assertBackendServiceEquals(api().get(BACKEND_SERVICE_NAME), backendService);
@@ -75,12 +75,11 @@ public class BackendServiceApiLiveTest extends BaseGoogleComputeEngineApiLiveTes
    public void testUpdateBackendService() {
       String fingerprint = api().get(BACKEND_SERVICE_NAME).fingerprint();
 
-      BackendServiceOptions backendService = new BackendServiceOptions()
-              .name(BACKEND_SERVICE_NAME)
-              .healthChecks(ImmutableList.of(getHealthCheckUrl(BACKEND_SERVICE_HEALTH_CHECK_NAME)))
+      BackendServiceOptions backendService = new BackendServiceOptions.Builder(BACKEND_SERVICE_NAME, ImmutableList.of(getHealthCheckUrl(BACKEND_SERVICE_HEALTH_CHECK_NAME)))
               .timeoutSec(45)
               .port(8080)
-              .fingerprint(fingerprint);
+              .fingerprint(fingerprint)
+              .build();
 
       assertOperationDoneSuccessfully(api().update(BACKEND_SERVICE_NAME, backendService));
       assertBackendServiceEquals(api().get(BACKEND_SERVICE_NAME),
@@ -119,13 +118,13 @@ public class BackendServiceApiLiveTest extends BaseGoogleComputeEngineApiLiveTes
    }
 
    private void assertBackendServiceEquals(BackendService result, BackendServiceOptions expected) {
-      assertEquals(result.name(), expected.getName());
-      assertEquals(result.healthChecks(), expected.getHealthChecks());
-      if (expected.getTimeoutSec() != null) {
-         org.testng.Assert.assertEquals(result.timeoutSec(), expected.getTimeoutSec().intValue());
+      assertEquals(result.name(), expected.name());
+      assertEquals(result.healthChecks(), expected.healthChecks());
+      if (expected.timeoutSec() != null) {
+         org.testng.Assert.assertEquals(result.timeoutSec(), expected.timeoutSec().intValue());
       }
-      if (expected.getPort() != null) {
-         org.testng.Assert.assertEquals(result.port(), expected.getPort().intValue());
+      if (expected.port() != null) {
+         org.testng.Assert.assertEquals(result.port(), expected.port().intValue());
       }
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/BackendServiceApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/BackendServiceApiMockTest.java
@@ -57,11 +57,11 @@ public class BackendServiceApiMockTest extends BaseGoogleComputeEngineApiMockTes
       List<URI> healthChecks = ImmutableList.of(URI.create(url("/projects/"
             + "myproject/global/httpHealthChecks/jclouds-test")));
 
-      assertEquals(backendServiceApi().create( new BackendServiceOptions().name("jclouds-test")
+      assertEquals(backendServiceApi().create( new BackendServiceOptions.Builder("jclouds-test", healthChecks)
             .protocol("HTTP")
             .port(80)
             .timeoutSec(30)
-            .healthChecks(healthChecks)),
+            .build()),
             new ParseOperationTest().expected(url("/projects")));
 
       assertSent(server, "POST", "/projects/party/global/backendServices",
@@ -75,11 +75,11 @@ public class BackendServiceApiMockTest extends BaseGoogleComputeEngineApiMockTes
             + "myproject/global/httpHealthChecks/jclouds-test")));
 
       assertEquals(backendServiceApi().update("jclouds-test",
-            new BackendServiceOptions().name("jclouds-test")
+            new BackendServiceOptions.Builder("jclouds-test", healthChecks)
                .protocol("HTTP")
                .port(80)
                .timeoutSec(30)
-               .healthChecks(healthChecks)),
+               .build()),
             new ParseOperationTest().expected(url("/projects")));
       assertSent(server, "PUT", "/projects/party/global/backendServices/jclouds-test",
             stringFromResource("/backend_service_insert.json"));
@@ -92,11 +92,11 @@ public class BackendServiceApiMockTest extends BaseGoogleComputeEngineApiMockTes
             + "myproject/global/httpHealthChecks/jclouds-test")));
 
       assertEquals(backendServiceApi().patch("jclouds-test",
-            new BackendServiceOptions().name("jclouds-test")
+            new BackendServiceOptions.Builder("jclouds-test", healthChecks)
                .protocol("HTTP")
                .port(80)
                .timeoutSec(30)
-               .healthChecks(healthChecks)),
+               .build()),
             new ParseOperationTest().expected(url("/projects")));
       assertSent(server, "PATCH", "/projects/party/global/backendServices/jclouds-test",
             stringFromResource("/backend_service_insert.json"));

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiLiveTest.java
@@ -42,7 +42,7 @@ public class DiskApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
    @Test(groups = "live")
    public void testInsertDisk() {
-      DiskCreationOptions options = new DiskCreationOptions().sizeGb( SIZE_GB);
+      DiskCreationOptions options = new DiskCreationOptions.Builder().sizeGb( SIZE_GB).build();
       assertOperationDoneSuccessfully(api().create(DISK_NAME, options));
    }
 
@@ -78,7 +78,7 @@ public class DiskApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    @Test(groups = "live")
    public void testInsertSSDDisk() {
       URI diskType = getDiskTypeUrl(DEFAULT_ZONE_NAME, "pd-ssd");
-      DiskCreationOptions diskCreationOptions = new DiskCreationOptions().type(diskType).sizeGb(SIZE_GB);
+      DiskCreationOptions diskCreationOptions = new DiskCreationOptions.Builder().type(diskType).sizeGb(SIZE_GB).build();
       assertOperationDoneSuccessfully(api().create(SSD_DISK_NAME, diskCreationOptions));
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/DiskApiMockTest.java
@@ -52,7 +52,7 @@ public class DiskApiMockTest extends BaseGoogleComputeEngineApiMockTest {
    public void insert() throws Exception {
       server.enqueue(jsonResponse("/zone_operation.json"));
 
-      DiskCreationOptions options = new DiskCreationOptions().sizeGb(1);
+      DiskCreationOptions options = new DiskCreationOptions.Builder().sizeGb(1).build();
       assertEquals(diskApi().create("testimage1", options),
             new ParseZoneOperationTest().expected(url("/projects")));
 
@@ -63,7 +63,7 @@ public class DiskApiMockTest extends BaseGoogleComputeEngineApiMockTest {
    public void insertFromImage() throws Exception {
       server.enqueue(jsonResponse("/zone_operation.json"));
 
-      DiskCreationOptions diskCreationOptions = new DiskCreationOptions().sizeGb(1).description("testing 123");
+      DiskCreationOptions diskCreationOptions = new DiskCreationOptions.Builder().sizeGb(1).description("testing 123").build();
 
       assertEquals(diskApi().create("testimage1", url(IMAGE_URL), diskCreationOptions),
             new ParseZoneOperationTest().expected(url("/projects")));
@@ -76,8 +76,8 @@ public class DiskApiMockTest extends BaseGoogleComputeEngineApiMockTest {
    public void insertFromSSD() throws Exception {
       server.enqueue(jsonResponse("/zone_operation.json"));
 
-      DiskCreationOptions diskCreationOptions = new DiskCreationOptions()
-         .type(URI.create(url(SSD_URL))).sizeGb(1);
+      DiskCreationOptions diskCreationOptions = new DiskCreationOptions.Builder()
+         .type(URI.create(url(SSD_URL))).sizeGb(1).build();
 
       assertEquals(diskApi().create("testimage1", diskCreationOptions),
             new ParseZoneOperationTest().expected(url("/projects")));

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ForwardingRuleApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ForwardingRuleApiLiveTest.java
@@ -82,11 +82,12 @@ public class ForwardingRuleApiLiveTest extends BaseGoogleComputeEngineApiLiveTes
 
    @Test(groups = "live")
    public void testInsertForwardingRule() {
-      ForwardingRuleCreationOptions forwardingRuleCreationOptions = new ForwardingRuleCreationOptions()
+      ForwardingRuleCreationOptions forwardingRuleCreationOptions = new ForwardingRuleCreationOptions.Builder()
                                                                            .description(DESCRIPTION)
                                                                            .ipAddress(address.address())
                                                                            .ipProtocol(ForwardingRule.IPProtocol.TCP)
-                                                                           .target(targetPool.selfLink());
+                                                                           .target(targetPool.selfLink())
+                                                                           .build();
       assertOperationDoneSuccessfully(api().create(FORWARDING_RULE_NAME, forwardingRuleCreationOptions));
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ForwardingRuleApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ForwardingRuleApiMockTest.java
@@ -50,8 +50,8 @@ public class ForwardingRuleApiMockTest extends BaseGoogleComputeEngineApiMockTes
    public void insert() throws Exception {
       server.enqueue(jsonResponse("/region_operation.json"));
 
-      ForwardingRuleCreationOptions forwardingRuleCreationOptions = new ForwardingRuleCreationOptions()
-      .target(URI.create(url("/projects/party/regions/europe-west1/targetPools/test-target-pool")));
+      ForwardingRuleCreationOptions forwardingRuleCreationOptions = new ForwardingRuleCreationOptions.Builder()
+      .target(URI.create(url("/projects/party/regions/europe-west1/targetPools/test-target-pool"))).build();
       assertEquals(forwardingRuleApi().create("test-forwarding-rule", forwardingRuleCreationOptions),
             new ParseRegionOperationTest().expected(url("/projects")));
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalForwardingRuleApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalForwardingRuleApiLiveTest.java
@@ -61,8 +61,7 @@ public class GlobalForwardingRuleApiLiveTest extends BaseGoogleComputeEngineApiL
 
 
       List<URI> healthChecks = ImmutableList.of(getHealthCheckUrl(GLOBAL_FORWARDING_RULE_HEALTH_CHECK_NAME));
-      BackendServiceOptions b = new BackendServiceOptions().name(GLOBAL_FORWARDING_RULE_BACKEND_SERVICE_NAME)
-                                                           .healthChecks(healthChecks);
+      BackendServiceOptions b = new BackendServiceOptions.Builder(GLOBAL_FORWARDING_RULE_BACKEND_SERVICE_NAME, healthChecks).build();
       assertOperationDoneSuccessfully(api.backendServices()
                                               .create(b));
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalForwardingRuleApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalForwardingRuleApiLiveTest.java
@@ -75,18 +75,19 @@ public class GlobalForwardingRuleApiLiveTest extends BaseGoogleComputeEngineApiL
                                                       getUrlMapUrl(GLOBAL_FORWARDING_RULE_URL_MAP_NAME)));
       assertOperationDoneSuccessfully(
             api().create(GLOBAL_FORWARDING_RULE_NAME,
-                         new ForwardingRuleCreationOptions().target(getTargetHttpProxyUrl(GLOBAL_FORWARDING_RULE_TARGET_HTTP_PROXY_NAME))
-                                                    .portRange(PORT_RANGE)));
+                         new ForwardingRuleCreationOptions.Builder().target(getTargetHttpProxyUrl(GLOBAL_FORWARDING_RULE_TARGET_HTTP_PROXY_NAME))
+                                                    .portRange(PORT_RANGE).build()));
    }
 
    @Test(groups = "live", dependsOnMethods = "testInsertGlobalForwardingRule")
    public void testGetGlobalForwardingRule() {
       ForwardingRule forwardingRule = api().get(GLOBAL_FORWARDING_RULE_NAME);
       assertNotNull(forwardingRule);
-      ForwardingRuleCreationOptions expected = new ForwardingRuleCreationOptions()
+      ForwardingRuleCreationOptions expected = new ForwardingRuleCreationOptions.Builder()
             .target(getTargetHttpProxyUrl(GLOBAL_FORWARDING_RULE_TARGET_HTTP_PROXY_NAME))
             .portRange("80-80")
-            .ipProtocol(IPProtocol.TCP);
+            .ipProtocol(IPProtocol.TCP)
+            .build();
       assertGlobalForwardingRuleEquals(forwardingRule, expected);
    }
 
@@ -127,10 +128,10 @@ public class GlobalForwardingRuleApiLiveTest extends BaseGoogleComputeEngineApiL
    }
 
    private void assertGlobalForwardingRuleEquals(ForwardingRule result, ForwardingRuleCreationOptions expected) {
-      assertEquals(result.target(), expected.getTarget());
-      assertEquals(result.ipProtocol(), expected.getIPProtocol());
-      assertEquals(result.description(), expected.getDescription());
-      assertEquals(result.portRange(), expected.getPortRange());
+      assertEquals(result.target(), expected.target());
+      assertEquals(result.ipProtocol(), expected.ipProtocol());
+      assertEquals(result.description(), expected.description());
+      assertEquals(result.portRange(), expected.portRange());
       assertTrue(result.ipAddress() != null);
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalForwardingRuleApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/GlobalForwardingRuleApiMockTest.java
@@ -50,8 +50,8 @@ public class GlobalForwardingRuleApiMockTest extends BaseGoogleComputeEngineApiM
    public void insert() throws Exception {
       server.enqueue(jsonResponse("/region_operation.json"));
 
-      ForwardingRuleCreationOptions forwardingRuleCreationOptions = new ForwardingRuleCreationOptions()
-      .target(URI.create(url("/projects/party/regions/europe-west1/targetPools/test-target-pool")));
+      ForwardingRuleCreationOptions forwardingRuleCreationOptions = new ForwardingRuleCreationOptions.Builder()
+      .target(URI.create(url("/projects/party/regions/europe-west1/targetPools/test-target-pool"))).build();
 
       assertEquals(globalForwardingRuleApi().create("test-forwarding-rule", forwardingRuleCreationOptions),
             new ParseRegionOperationTest().expected(url("/projects")));

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiLiveTest.java
@@ -70,7 +70,7 @@ public class ImageApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    @Test(groups = "live")
    public void testInsertDisk() {
       assertOperationDoneSuccessfully(diskApi().create(DISK_NAME,
-            new DiskCreationOptions().sizeGb(sizeGb)));
+            new DiskCreationOptions.Builder().sizeGb(sizeGb).build()));
       Disk disk = diskApi().get(DISK_NAME);
       diskURI = disk.selfLink();
    }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiLiveTest.java
@@ -96,11 +96,12 @@ public class ImageApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
 
       URI replacement = URI.create("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-2-v20120326test");
 
-      DeprecateOptions deprecateOptions = new DeprecateOptions().state(State.DEPRECATED)
+      DeprecateOptions deprecateOptions = new DeprecateOptions.Builder().state(State.DEPRECATED)
             .replacement(replacement)
             .deprecated(new SimpleDateFormatDateService().iso8601DateParse(deprecated))
             .obsolete(new SimpleDateFormatDateService().iso8601DateParse(obsolete))
-            .deleted(new SimpleDateFormatDateService().iso8601DateParse(deleted));
+            .deleted(new SimpleDateFormatDateService().iso8601DateParse(deleted))
+            .build();
 
       assertOperationDoneSuccessfully(api().deprecate(IMAGE_NAME, deprecateOptions));
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/ImageApiMockTest.java
@@ -136,11 +136,12 @@ public class ImageApiMockTest extends BaseGoogleComputeEngineApiMockTest {
       String imageName = "test-image";
       server.enqueue(jsonResponse("/operation.json"));
 
-      DeprecateOptions options = new DeprecateOptions().state(State.DEPRECATED)
+      DeprecateOptions options = new DeprecateOptions.Builder().state(State.DEPRECATED)
             .replacement(URI.create(url("/projects/centos-cloud/global/images/centos-6-2-v20120326test")))
             .deprecated(new SimpleDateFormatDateService().iso8601DateParse("2014-07-16T22:16:13.468Z"))
             .obsolete(new SimpleDateFormatDateService().iso8601DateParse("2014-10-16T22:16:13.468Z"))
-            .deleted(new SimpleDateFormatDateService().iso8601DateParse("2015-01-16T22:16:13.468Z"));
+            .deleted(new SimpleDateFormatDateService().iso8601DateParse("2015-01-16T22:16:13.468Z"))
+            .build();
 
       assertEquals(imageApi().deprecate(imageName, options),
             new ParseOperationTest().expected(url("/projects")));

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
@@ -122,7 +122,7 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
               (INSTANCE_NETWORK_NAME, IPV4_RANGE));
 
       assertOperationDoneSuccessfully(diskApi().create(DISK_NAME,
-            new DiskCreationOptions().sizeGb(DEFAULT_DISK_SIZE_GB)));
+            new DiskCreationOptions.Builder().sizeGb(DEFAULT_DISK_SIZE_GB).build()));
       assertOperationDoneSuccessfully(api().create(instance));
       assertOperationDoneSuccessfully(api().create(instance2));
    }
@@ -236,7 +236,7 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    @Test(groups = "live", dependsOnMethods = "testSetMetadataForInstance")
    public void testAttachDiskToInstance() {
       assertOperationDoneSuccessfully(diskApi().create(ATTACH_DISK_NAME,
-            new DiskCreationOptions().sizeGb(1)));
+            new DiskCreationOptions.Builder().sizeGb(1).build()));
 
       Instance originalInstance = api().get(INSTANCE_NAME);
       assertOperationDoneSuccessfully(api().attachDisk(INSTANCE_NAME,

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/SnapshotApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/SnapshotApiLiveTest.java
@@ -46,7 +46,7 @@ public class SnapshotApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    @Test(groups = "live")
    public void testCreateSnapshot() {
       assertOperationDoneSuccessfully(diskApi().create(DISK_NAME,
-            new DiskCreationOptions().sizeGb(1)));
+            new DiskCreationOptions.Builder().sizeGb(1).build()));
       disk = diskApi().get(DISK_NAME);
 
       assertOperationDoneSuccessfully(diskApi().createSnapshot(DISK_NAME, SNAPSHOT_NAME));

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/TargetHttpProxyApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/TargetHttpProxyApiLiveTest.java
@@ -52,8 +52,8 @@ public class TargetHttpProxyApiLiveTest extends BaseGoogleComputeEngineApiLiveTe
       assertOperationDoneSuccessfully(api.httpHeathChecks().insert(HEALTH_CHECK_NAME));
 
       List<URI> healthChecks = ImmutableList.of(getHealthCheckUrl(HEALTH_CHECK_NAME));
-      BackendServiceOptions b = new BackendServiceOptions().name(URL_MAP_DEFAULT_SERVICE_NAME)
-                                                           .healthChecks(healthChecks);
+      BackendServiceOptions b = new BackendServiceOptions.Builder(URL_MAP_DEFAULT_SERVICE_NAME, healthChecks)
+                                                           .build();
 
       assertOperationDoneSuccessfully(api.backendServices().create(b));
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/TargetPoolApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/TargetPoolApiLiveTest.java
@@ -115,10 +115,11 @@ public class TargetPoolApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
       TargetPool targetPool = api().get(TARGETPOOL_NAME);
       URI target = targetPool.selfLink();
 
-      ForwardingRuleCreationOptions forwardingRuleOptions = new ForwardingRuleCreationOptions()
+      ForwardingRuleCreationOptions forwardingRuleOptions = new ForwardingRuleCreationOptions.Builder()
          .ipProtocol(IPProtocol.TCP)
          .portRange("80-80")
-         .target(target);
+         .target(target)
+         .build();
 
       assertOperationDoneSuccessfully(api.forwardingRulesInRegion(DEFAULT_REGION_NAME)
                .create(FORWARDING_RULE_NAME, forwardingRuleOptions));

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/UrlMapApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/UrlMapApiLiveTest.java
@@ -54,8 +54,7 @@ public class UrlMapApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
       assertOperationDoneSuccessfully(api.httpHeathChecks().insert(HEALTH_CHECK_NAME));
 
       List<URI> healthChecks = ImmutableList.of(getHealthCheckUrl(HEALTH_CHECK_NAME));
-      BackendServiceOptions b = new BackendServiceOptions().name(URL_MAP_BACKEND_SERVICE_NAME)
-                                                           .healthChecks(healthChecks);
+      BackendServiceOptions b = new BackendServiceOptions.Builder(URL_MAP_BACKEND_SERVICE_NAME, healthChecks).build();
       assertOperationDoneSuccessfully(api.backendServices().create(b));
 
       UrlMapOptions map = new UrlMapOptions.Builder().name(URL_MAP_NAME).description("simple url map")


### PR DESCRIPTION
Converts another Options class to AutoValue + Builder 

For consistency I think all Options classes should be converted to AutoValue + Builder.
Sound good? Should I continue down this path? 