### PR TITLE
Fix if-statement that always returns true

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobStore.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobStore.java
@@ -226,7 +226,7 @@ public final class GoogleCloudStorageBlobStore extends BaseBlobStore {
 
    @Override
    public String putBlob(String container, Blob blob, PutOptions options) {
-      if (options.multipart().isMultipart()) {
+      if (options.isMultipart()) {
          return multipartUploadStrategy.get().execute(container, blob);
       } else {
          return putBlob(container, blob);


### PR DESCRIPTION
At first glance, that's a pretty simple fix but I don't really understand what it amounts to, in terms of functionality.
Here's the code for ``putBlob()``:

```java
   @Override
   public String putBlob(String container, Blob blob) {
      checkNotNull(blob.getPayload().getContentMetadata().getContentLength());
      HashCode md5 = blob.getMetadata().getContentMetadata().getContentMD5AsHashCode();

      ObjectTemplate template = blobMetadataToObjectTemplate.apply(blob.getMetadata());

      if (md5 != null) {
         template.md5Hash(base64().encode(md5.asBytes()));
      }
      return api.getObjectApi().multipartUpload(container, template, blob.getPayload()).etag();
   }

   @Override
   public String putBlob(String container, Blob blob, PutOptions options) {
      if (options.isMultipart()) {
         return multipartUploadStrategy.get().execute(container, blob);
      } else {
         return putBlob(container, blob);
      }
   }
```

In the first case of the if-statement, why is a ``MultipartUploadStrategy`` used... while ``ObjectApi.multipartUpload()`` is also apparently using some multipart mechanism?!?