### PR TITLE
JCLOUD-875: GCS Copy Object with Updated Metadata

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobStore.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobStore.java
@@ -23,6 +23,7 @@ import static org.jclouds.googlecloudstorage.domain.DomainResourceReferences.Obj
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Set;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -41,6 +42,7 @@ import org.jclouds.blobstore.options.CreateContainerOptions;
 import org.jclouds.blobstore.options.GetOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
+import org.jclouds.blobstore.options.CopyOptions;
 import org.jclouds.blobstore.strategy.internal.FetchBlobMetadata;
 import org.jclouds.blobstore.util.BlobUtils;
 import org.jclouds.collect.Memoized;
@@ -302,4 +304,17 @@ public final class GoogleCloudStorageBlobStore extends BaseBlobStore {
 
       return false;
    }
+
+    @Override
+    public String copyBlob(String fromContainer, String fromName, String toContainer, String toName, CopyOptions options) {
+
+        if (options == CopyOptions.NONE) {
+           return api.getObjectApi().copyObject(toContainer, toName, fromContainer, fromName).etag();
+        } else {
+            Map<String, String> map = options.getUserMetadata().get();
+            String contentType = api.getObjectApi().getObject(fromContainer, fromName).contentType();
+            ObjectTemplate template = new ObjectTemplate().customMetadata(map).contentType(contentType);
+            return api.getObjectApi().copyObject(toContainer, toName, fromContainer, fromName, template).etag();
+        }
+    }
 }

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
@@ -380,7 +380,7 @@ public interface ObjectApi {
             ComposeObjectOptions options);
 
    /**
-    * Copies an object to a specified location. Optionally overrides metadata.
+    * Copies an object to a specified location.
     *
     * @param destinationBucket
     *           Name of the bucket in which to store the new object
@@ -400,6 +400,30 @@ public interface ObjectApi {
    GoogleCloudStorageObject copyObject(@PathParam("destinationBucket") String destinationBucket,
             @PathParam("destinationObject") String destinationObject, @PathParam("sourceBucket") String sourceBucket,
             @PathParam("sourceObject") String sourceObject);
+
+    /**
+     * Copies an object to a specified location with updated metadata.
+     *
+     * @param destinationBucket
+     *           Name of the bucket in which to store the new object
+     * @param destinationObject
+     *           Name of the new object.
+     * @param sourceBucket
+     *           Name of the bucket in which to find the source object
+     * @param sourceObject
+     *           Name of the source object
+     * @param template
+     *           Supply a {@link CopyObjectOptions}
+     *
+     * @return a {@link GoogleCloudStorageObject}
+     */
+    @Named("Object:copy")
+    @POST
+    @Consumes(APPLICATION_JSON)
+    @Path("/storage/v1/b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}")
+    GoogleCloudStorageObject copyObject(@PathParam("destinationBucket") String destinationBucket,
+                                        @PathParam("destinationObject") String destinationObject, @PathParam("sourceBucket") String sourceBucket,
+                                        @PathParam("sourceObject") String sourceObject, @BinderParam(BindToJsonPayload.class) ObjectTemplate template);
 
    /**
     * Copies an object to a specified location. Optionally overrides metadata.

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiLiveTest.java
@@ -73,6 +73,7 @@ public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
    private static final String UPLOAD_OBJECT_NAME2 = "jcloudslogo.jpg";
    private static final String MULTIPART_UPLOAD_OBJECT = "multipart_related.jpg";
    private static final String COPIED_OBJECT_NAME = "copyofObjectOperation.txt";
+   private static final String COPIED_OBJECT_NAME2 = "copyObjectWithMeta.txt";
    private static final String COMPOSED_OBJECT = "ComposedObject1.txt";
    private static final String COMPOSED_OBJECT2 = "ComposedObject2.json";
    private static final String NONEXISTENT_OBJECT_NAME = "noSuchObject.txt";
@@ -205,20 +206,48 @@ public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
 
    }
 
+    @Test(groups = "live", dependsOnMethods = "testGetObject")
+    public void testCopyObjectWithUpdatedMetadata() throws IOException {
+        String METADATA_KEY = "key1";
+        String METADATA_VALUE = "value1";
+
+        ObjectTemplate template = new ObjectTemplate().contentLanguage("fr").contentType("text/plain")
+                .contentDisposition("attachment").customMetadata(METADATA_KEY, METADATA_VALUE);
+
+        GoogleCloudStorageObject gcsObject = api().copyObject(BUCKET_NAME2, COPIED_OBJECT_NAME2, BUCKET_NAME, UPLOAD_OBJECT_NAME, template);
+
+        assertNotNull(gcsObject);
+        assertEquals(gcsObject.bucket(), BUCKET_NAME2);
+        assertEquals(gcsObject.name(), COPIED_OBJECT_NAME2);
+        assertNotNull(gcsObject.acl());
+        assertEquals(gcsObject.contentType(), "text/plain");
+        assertEquals(gcsObject.metadata().get(METADATA_KEY), METADATA_VALUE);
+        assertEquals(gcsObject.contentLanguage(), "fr");
+        // Test for data
+
+        PayloadEnclosing impl = api().download(BUCKET_NAME2, COPIED_OBJECT_NAME2);
+        assertNotNull(impl);
+        assertEquals(ByteStreams2.toByteArrayAndClose(impl.getPayload().openStream()),
+                ByteStreams2.toByteArrayAndClose(testPayload.getPayload().openStream()));
+
+    }
+
    @Test(groups = "live", dependsOnMethods = "testCopyObject")
-   public void testCopyObjectWithOptions() {
-      CopyObjectOptions options = new CopyObjectOptions().ifSourceGenerationMatch(generation)
-               .ifSourceMetagenerationMatch(metageneration).projection(Projection.FULL);
+       public void testCopyObjectWithOptions() {
+        CopyObjectOptions options = new CopyObjectOptions().ifSourceGenerationMatch(generation)
+                .ifSourceMetagenerationMatch(metageneration).projection(Projection.FULL);
 
-      GoogleCloudStorageObject gcsObject = api()
-               .copyObject(BUCKET_NAME2, UPLOAD_OBJECT_NAME, BUCKET_NAME, UPLOAD_OBJECT_NAME, options);
+        GoogleCloudStorageObject gcsObject = api()
+                .copyObject(BUCKET_NAME2, UPLOAD_OBJECT_NAME, BUCKET_NAME, UPLOAD_OBJECT_NAME, options);
 
-      assertNotNull(gcsObject);
-      assertNotNull(gcsObject.acl());
-      assertEquals(gcsObject.bucket(), BUCKET_NAME2);
-      assertEquals(gcsObject.name(), UPLOAD_OBJECT_NAME);
-      assertEquals(gcsObject.contentType(), "text/plain");
-   }
+        assertNotNull(gcsObject);
+        assertNotNull(gcsObject.acl());
+        assertEquals(gcsObject.bucket(), BUCKET_NAME2);
+        assertEquals(gcsObject.name(), UPLOAD_OBJECT_NAME);
+        assertEquals(gcsObject.contentType(), "text/plain");
+    }
+
+
 
    @Test(groups = "live", dependsOnMethods = "testCopyObjectWithOptions")
    public void testComposeObject() {

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
@@ -210,6 +210,21 @@ public class ObjectApiMockTest extends BaseGoogleCloudStorageApiMockTest {
               "/b/destination_bucket/o/destination_object", APPLICATION_JSON);
    }
 
+    public void copy_update_metadata() throws Exception {
+        server.enqueue(jsonResponse("/object_get.json"));
+
+        ObjectTemplate template = new ObjectTemplate().name("file_name").size((long) 1000).crc32c("crc32c");
+
+        assertEquals(objectApi().copyObject("destination_bucket", "destination_object", "source_bucket", "source_object", template),
+                new ParseGoogleCloudStorageObject().expected());
+        assertSent(server, "POST", "/storage/v1/b/source_bucket/o/source_object/copyTo" +
+                "/b/destination_bucket/o/destination_object", APPLICATION_JSON, "{" +
+                "  \"name\": \"file_name\"," +
+                "  \"size\": 1000," +
+                "  \"crc32c\": \"crc32c\"" +
+                "}");
+    }
+
    public void copy_with_options() throws Exception {
       server.enqueue(jsonResponse("/object_get.json"));
 


### PR DESCRIPTION
1- Update metadata support in feature API.
2- CopyBlob Operation

Note: Working on Windows I'm getting few live test failiures.