### PR TITLE
WIP: JCLOUDS-908  fix to InstanceToNodeMetadata

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/FirewallTagNamingConvention.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/FirewallTagNamingConvention.java
@@ -22,8 +22,6 @@ import javax.inject.Inject;
 
 import org.jclouds.compute.functions.GroupNamingConvention;
 
-import com.google.common.base.Predicate;
-
 /**
  * The convention for naming instance tags that firewall rules recognise.
  */
@@ -57,15 +55,5 @@ public final class FirewallTagNamingConvention {
       }
 
       return String.format("%s-%s", sharedResourceName, Integer.toHexString(result));
-   }
-
-
-   public Predicate<String> isFirewallTag() {
-      return new Predicate<String>() {
-         @Override
-         public boolean apply(String input) {
-            return input != null && input.startsWith(sharedResourceName + "-port-");
-         }
-      };
    }
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/NewInstance.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/NewInstance.java
@@ -77,10 +77,10 @@ public abstract class NewInstance {
 
    /** Convenience for creating a new instance with only a boot disk and minimal parameters. */
    public static NewInstance create(String name, URI machineType, URI network, URI sourceImage) {
-      return create(name, machineType, network, Arrays.asList(AttachDisk.newBootDisk(sourceImage)), null);
+      return create(name, machineType, network, Arrays.asList(AttachDisk.newBootDisk(sourceImage)), null, null);
    }
 
-   public static NewInstance create(String name, URI machineType, URI network, List<AttachDisk> disks, String description) {
+   public static NewInstance create(String name, URI machineType, URI network, List<AttachDisk> disks, @Nullable String description, @Nullable Tags tags) {
       checkArgument(disks.get(0).boot(), "disk 0 must be a boot disk! %s", disks);
       boolean foundBoot = false;
       for (AttachDisk disk : disks) {
@@ -90,7 +90,7 @@ public abstract class NewInstance {
          }
       }
       return create(name, machineType, null, ImmutableList.of(NetworkInterface.create(network)), ImmutableList.copyOf(disks),
-            description, Tags.create(), Metadata.create(), null, null);
+            description, tags != null ? tags : Tags.create(), Metadata.create(), null, null);
    }
 
    @SerializedNames({ "name", "machineType", "canIpForward", "networkInterfaces", "disks", "description", "tags", "metadata",

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Tags.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Tags.java
@@ -16,13 +16,11 @@
  */
 package org.jclouds.googlecomputeengine.domain;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Tags for an instance or project, with their fingerprint. Each tag must be unique, must be 1-63 characters long, and
@@ -35,14 +33,8 @@ public abstract class Tags implements Cloneable {
    /** The fingerprint for the items - needed for updating them. */
    @Nullable public abstract String fingerprint();
 
-   /** Mutable list of tags. */
-   public abstract List<String> items();
-
-   /** Convenience method for chaining adds. */
-   public Tags add(String tag) {
-      items().add(tag);
-      return this;
-   }
+   /** Immutable list of tags. */
+   public abstract ImmutableList<String> items();
 
    public static Tags create() {
       return Tags.create(null, null);
@@ -53,14 +45,15 @@ public abstract class Tags implements Cloneable {
    }
 
    @SerializedNames({ "fingerprint", "items" })
-   static Tags create(String fingerprint, ArrayList<String> items) { // Dictates the type when created from json!
-      return new AutoValue_Tags(fingerprint, items != null ? items : new ArrayList<String>());
+   public static Tags create(String fingerprint, ImmutableList<String> items) { // Dictates the type when created from json!
+      ImmutableList<String> empty = ImmutableList.of();
+      return new AutoValue_Tags(fingerprint, items != null ? items : empty);
    }
 
    Tags() {
    }
 
    @Override public Tags clone() {
-      return Tags.create(fingerprint(), new ArrayList<String>(items()));
+      return Tags.create(fingerprint(), items());
    }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/InstanceToNodeMetadataTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/InstanceToNodeMetadataTest.java
@@ -178,18 +178,7 @@ public class InstanceToNodeMetadataTest {
             namingConventionFactory,
             ImmutableMap.of(instance.disks().get(0).source(), imageUrl),
             hardwareSupplier,
-            locationSupplier,
-            new FirewallTagNamingConvention.Factory(namingConventionFactory));
-   }
-
-   @Test
-   public final void testTagFilteringWorks() {
-      NodeMetadata nodeMetadata = groupGroupNodeParser.apply(instance);
-      assertEquals(nodeMetadata.getId(), instance.selfLink().toString());
-      assertEquals(nodeMetadata.getTags(), ImmutableSet.of(
-            "aTag"  // "aTag" kept as a non firewall tag.
-            // "Group-port-42" filtered out as a firewall tag.
-      ));
+            locationSupplier);
    }
 
    @Test

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
@@ -40,6 +40,7 @@ import org.jclouds.googlecomputeengine.domain.Metadata;
 import org.jclouds.googlecomputeengine.domain.NewInstance;
 import org.jclouds.googlecomputeengine.domain.AttachDisk;
 import org.jclouds.googlecomputeengine.domain.Operation;
+import org.jclouds.googlecomputeengine.domain.Tags;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineApiLiveTest;
 import org.jclouds.googlecomputeengine.options.DiskCreationOptions;
 import org.testng.annotations.AfterClass;
@@ -93,9 +94,9 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
             getNetworkUrl(INSTANCE_NETWORK_NAME), // network
             Arrays.asList(AttachDisk.newBootDisk(imageUri),
                   AttachDisk.existingDisk(getDiskUrl(DISK_NAME))), // disks
-            "a description" // description
+            "a description", // description
+            Tags.create(null, ImmutableList.of("foo", "bar")) // tags
       );
-      instance.tags().items().addAll(Arrays.asList("foo", "bar"));
       instance.metadata().put("mykey", "myvalue");
 
       instance2 = NewInstance.create(

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiMockTest.java
@@ -88,7 +88,8 @@ public class InstanceApiMockTest extends BaseGoogleComputeEngineApiMockTest {
             URI.create(url("/projects/party/zones/us-central1-a/machineTypes/n1-standard-1")), // machineType
             URI.create(url("/projects/party/global/networks/default")), // network
             Arrays.asList(AttachDisk.existingBootDisk(URI.create(url("/projects/party/zones/us-central1-a/disks/test")))),
-            "desc" // description
+            "desc", // description
+            null // tags
       );
 
       newInstance.metadata().put("aKey", "aValue");

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceTest.java
@@ -57,7 +57,7 @@ public class ParseInstanceTest extends BaseGoogleComputeEngineParseTest<Instance
             URI.create(baseUrl + "/party/zones/us-central1-a/instances/test-0"), // selfLink
             "test-0", // name
             "desc", // description
-            Tags.create("abcd").add("aTag").add("Group-port-42"), // tags
+            Tags.create("abcd", ImmutableList.of("aTag", "Group-port-42")), // tags
             URI.create(baseUrl + "/party/zones/us-central1-a/machineTypes/n1-standard-1"), // machineType
             Instance.Status.RUNNING, // status
             null, // statusMessage


### PR DESCRIPTION
This is probably also the root cause of JCLOUDS-657 (unconfirmed)

InstanceToNodeMetadata filters out firewall tags added to instances. This is causing BaseComputeService#listNodes to fail when it attempts to list nodes like j-t2. When constructing a `Predicate<String> isFirewallTag` DnsNameValidator is called and an IllegalArgumentException is thrown. 

Possible solutions:
 - We could remove the functionality for filtering out firewall tags now that there is only one firewall tag added to each instance instead of one per inbound port. 
 - We could add a try/catch block and ignore the IllegalArgumentException. 

I lean toward the first option of removing functionality for filtering out tags added by jclouds. 
@nacx  WDYT?