### PR TITLE
Allow GCS object nullable owner

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/GoogleCloudStorageObject.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/GoogleCloudStorageObject.java
@@ -59,7 +59,7 @@ public abstract class GoogleCloudStorageObject {
    @Nullable public abstract String contentLanguage();
    @Nullable public abstract String cacheControl();
    public abstract List<ObjectAccessControls> acl();
-   public abstract Owner owner();
+   @Nullable public abstract Owner owner();
    @Nullable public abstract String crc32c();
    @Nullable public abstract Integer componentCount();
 


### PR DESCRIPTION
This addresses a NullPointerException seen while listing a bucket:

`{statusCode=200, message=OK, headers={X-Frame-Options=[SAMEORIGIN], Server=[GSE], Cache-Control=[private, max-age=0, must-revalidate, no-transform], X-Content-Type-Options=[nosniff], Vary=[X-Origin, Origin], X-XSS-Protection=[1; mode=block], Date=[Fri, 29 May 2015 21:43:51 GMT], Alternate-Protocol=[443:quic,p=1]}, payload=[content=true, contentMetadata=[contentDisposition=null, contentEncoding=null, contentLanguage=null, contentLength=760, contentMD5=null, contentType=application/json; charset=UTF-8, expires=Fri May 29 14:43:51 PDT 2015], written=false]}`