### PR TITLE
Fix DefaultObjectAccessControlsApiLiveTest and ResumableUploadApiLive…

### DIFF
--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/DefaultObjectAccessControlsApiLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/DefaultObjectAccessControlsApiLiveTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 
 public class DefaultObjectAccessControlsApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
 
-   protected static final String BUCKET_NAME = "jcloudstestbucketdefaultoacl" + UUID.randomUUID();
+   protected static final String BUCKET_NAME = "jcloudsdefaultoacltest" + UUID.randomUUID();
 
    private DefaultObjectAccessControlsApi api() {
       return api.getDefaultObjectAccessControlsApi();

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiLiveTest.java
@@ -63,7 +63,6 @@ import com.beust.jcommander.internal.Lists;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteSource;
-import com.google.common.primitives.Bytes;
 
 public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
 
@@ -435,6 +434,7 @@ public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
       assertTrue(api().deleteObject(BUCKET_NAME2, COMPOSED_OBJECT2));
       assertTrue(api().deleteObject(BUCKET_NAME2, COMPOSED_OBJECT));
       assertTrue(api().deleteObject(BUCKET_NAME2, COPIED_OBJECT_NAME));
+      assertTrue(api().deleteObject(BUCKET_NAME2, COPIED_OBJECT_NAME2));
       assertFalse(api().deleteObject(BUCKET_NAME, UPLOAD_OBJECT_NAME));
       assertTrue(api().deleteObject(BUCKET_NAME, UPLOAD_OBJECT_NAME2));
       assertTrue(api().deleteObject(BUCKET_NAME, MULTIPART_UPLOAD_OBJECT));
@@ -452,11 +452,5 @@ public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
    private void deleteBucket() {
       api.getBucketApi().deleteBucket(BUCKET_NAME);
       api.getBucketApi().deleteBucket(BUCKET_NAME2);
-   }
-
-   private static byte[] reverse(byte[] b) {
-      List<Byte> hashByte = Bytes.asList(b);
-      List<Byte> reversedList = com.google.common.collect.Lists.reverse(hashByte);
-      return Bytes.toArray(reversedList);
    }
 }

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ResumableUploadApiLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ResumableUploadApiLiveTest.java
@@ -136,7 +136,7 @@ public class ResumableUploadApiLiveTest extends BaseGoogleCloudStorageApiLiveTes
       // Uploading First chunk
       ByteSourcePayload payload = Payloads.newByteSourcePayload(byteSource.slice(offset, chunkSize));
       long length = byteSource.slice(offset, chunkSize).size();
-      String Content_Range = generateContentRange(0L, length, totalSize);
+      String Content_Range = generateContentRange(0L, length - 1, totalSize);
       ResumableUpload uploadResponse = api().chunkUpload(BUCKET_NAME, uploadId, "application/pdf", length,
                Content_Range, payload);
 


### PR DESCRIPTION
…Test

DefaultObjectAccessControlsApiLiveTest was failing due to the bucket name exceeding the maximum name length of 63 characters. [described here](https://cloud.google.com/storage/docs/bucket-naming)

ResumableUploadApiLiveTest was failing due to an off by one error.

ObjectApiLiveTest was not deleting an object from one of the buckets.

