### PR TITLE
Added support for Preemptible instances in GCE

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Instance.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Instance.java
@@ -186,16 +186,18 @@ public abstract class Instance {
           * If you would like your instance to be restarted, set the automaticRestart flag to true.
           * Your instance may be restarted more than once, and it may be restarted outside the window
           * of maintenance events.
+          * If you would like your instance to be preemptible, set the preemptible flag to true.
           */
          TERMINATE
       }
 
       public abstract OnHostMaintenance onHostMaintenance();
       public abstract boolean automaticRestart();
+      public abstract boolean preemptible();
 
-      @SerializedNames({ "onHostMaintenance", "automaticRestart" })
-      public static Scheduling create(OnHostMaintenance onHostMaintenance, boolean automaticRestart) {
-         return new AutoValue_Instance_Scheduling(onHostMaintenance, automaticRestart);
+      @SerializedNames({ "onHostMaintenance", "automaticRestart", "preemptible" })
+      public static Scheduling create(OnHostMaintenance onHostMaintenance, boolean automaticRestart, boolean preemptible) {
+         return new AutoValue_Instance_Scheduling(onHostMaintenance, automaticRestart, preemptible);
       }
 
       Scheduling() {

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/InstanceApi.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/features/InstanceApi.java
@@ -241,6 +241,7 @@ public interface InstanceApi {
     * @param onHostMaintenance either MIGRATE or TERMINATE the default is MIGRATE (Live Migration).
     * @param automaticRestart Defines whether the Instance should be automatically
     *  restarted when it is terminated by Compute Engine (not terminated by user).
+    * @param preemptible Defines whether the Instance should be launched as spot instance
     *  Used when onHostMaintenance is set to TERMINATE.
     * @return
     */
@@ -250,7 +251,8 @@ public interface InstanceApi {
    @MapBinder(BindToJsonPayload.class)
    Operation setScheduling(@PathParam("instance") String instanceName,
                            @PayloadParam("onHostMaintenance") Scheduling.OnHostMaintenance onHostMaintenance,
-                           @PayloadParam("automaticRestart") boolean automaticRestart);
+                           @PayloadParam("automaticRestart") boolean automaticRestart,
+                           @PayloadParam("preemptible") boolean preemptible);
 
    /**
     * This method starts an instance that was stopped using the using the {@link #stop(String)} method.

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiLiveTest.java
@@ -132,6 +132,7 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
       assertEquals(instance.description(), "description");
       assertEquals(instance.serviceAccounts().get(0).scopes(), ImmutableList.of("https://www.googleapis.com/auth/compute"));
       assertTrue(instance.scheduling().automaticRestart());
+      assertFalse(instance.scheduling().preemptible());
       assertEquals(instance.scheduling().onHostMaintenance(), OnHostMaintenance.MIGRATE);
    }
 
@@ -205,12 +206,14 @@ public class InstanceApiLiveTest extends BaseGoogleComputeEngineApiLiveTest {
    public void testSetScheduling() {
       Instance instance = api().get(INSTANCE_NAME);
       assertEquals(instance.scheduling().automaticRestart(), true);
+      assertEquals(instance.scheduling().preemptible(), false);
       assertEquals(instance.scheduling().onHostMaintenance(), Scheduling.OnHostMaintenance.MIGRATE);
 
       assertOperationDoneSuccessfully(api().setScheduling(INSTANCE_NAME, Scheduling.OnHostMaintenance.TERMINATE, false));
 
       Instance instanceAltered = api().get(INSTANCE_NAME);
       assertEquals(instanceAltered.scheduling().automaticRestart(), false);
+      assertEquals(instance.scheduling().preemptible(), false);
       assertEquals(instanceAltered.scheduling().onHostMaintenance(), Scheduling.OnHostMaintenance.TERMINATE);
    }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiMockTest.java
@@ -231,7 +231,7 @@ public class InstanceApiMockTest extends BaseGoogleComputeEngineApiMockTest {
             new ParseZoneOperationTest().expected(url("/projects")));
 
       assertSent(server, "POST", "/projects/party/zones/us-central1-a/instances/test-1/setScheduling",
-            "{\"onHostMaintenance\": \"TERMINATE\",\"automaticRestart\": true}");
+            "{\"onHostMaintenance\": \"TERMINATE\",\"automaticRestart\": true,\"preemptible\": false}");
    }
 
    public void start_test() throws Exception {

--- a/google-compute-engine/src/test/resources/instance_get.json
+++ b/google-compute-engine/src/test/resources/instance_get.json
@@ -73,6 +73,7 @@
    },
     "scheduling": {
         "onHostMaintenance": "MIGRATE",
-        "automaticRestart": false
+        "automaticRestart": false,
+        "preemptible": false
    }
 }

--- a/google-compute-engine/src/test/resources/instance_insert_full.json
+++ b/google-compute-engine/src/test/resources/instance_insert_full.json
@@ -42,6 +42,7 @@
   ],
   "scheduling": {
     "onHostMaintenance": "MIGRATE",
-    "automaticRestart": true
+    "automaticRestart": true,
+    "preemptible": false
   }
 }

--- a/google-compute-engine/src/test/resources/instance_list.json
+++ b/google-compute-engine/src/test/resources/instance_list.json
@@ -78,7 +78,8 @@
       },
       "scheduling": {
         "onHostMaintenance": "MIGRATE",
-        "automaticRestart": false
+        "automaticRestart": false,
+        "preemptible": false
       }
     }
   ]


### PR DESCRIPTION
Google has introduced a new feature for compute engine that spawns
instances at a cheaper cost but for shorter durations. Useful for
developers for testing.