### PR TITLE
JCLOUDS-925 - add support for suspendNode/resumeNode to GCE

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceAdapter.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceAdapter.java
@@ -22,9 +22,11 @@ import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static org.jclouds.googlecloud.internal.ListPages.concat;
-import static org.jclouds.googlecomputeengine.config.GoogleComputeEngineProperties.IMAGE_PROJECTS;
 import static org.jclouds.googlecomputeengine.compute.strategy.CreateNodesWithGroupEncodedIntoNameThenAddToSet.simplifyPorts;
+import static org.jclouds.googlecomputeengine.config.GoogleComputeEngineProperties.IMAGE_PROJECTS;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -32,9 +34,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
+import com.google.common.base.Predicate;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Atomics;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
 import org.jclouds.compute.ComputeServiceAdapter;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.NodeMetadata;
@@ -61,15 +68,6 @@ import org.jclouds.googlecomputeengine.domain.Tags;
 import org.jclouds.googlecomputeengine.domain.Zone;
 import org.jclouds.googlecomputeengine.features.InstanceApi;
 import org.jclouds.location.suppliers.all.JustProvider;
-
-import com.google.common.base.Predicate;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.Atomics;
-import com.google.common.util.concurrent.UncheckedTimeoutException;
 
 /**
  * This implementation maps the following:
@@ -257,12 +255,12 @@ public final class GoogleComputeEngineServiceAdapter
       waitOperationDone(resources.resetInstance(URI.create(checkNotNull(selfLink, "id"))));
    }
 
-   @Override public void resumeNode(String name) {
-      throw new UnsupportedOperationException("resume is not supported by GCE");
+   @Override public void resumeNode(String selfLink) {
+      waitOperationDone(resources.startInstance(URI.create(checkNotNull(selfLink, "id"))));
    }
 
-   @Override  public void suspendNode(String name) {
-      throw new UnsupportedOperationException("suspend is not supported by GCE");
+   @Override  public void suspendNode(String selfLink) {
+      waitOperationDone(resources.stopInstance(URI.create(checkNotNull(selfLink, "id"))));
    }
 
    private void waitOperationDone(Operation operation) {

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/Resources.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/Resources.java
@@ -19,14 +19,14 @@ package org.jclouds.googlecomputeengine.compute.functions;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.jclouds.Fallbacks.NullOnNotFoundOr404;
 
-import java.net.URI;
-
 import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.net.URI;
 
 import org.jclouds.googlecomputeengine.domain.Instance;
 import org.jclouds.googlecomputeengine.domain.Network;
@@ -68,4 +68,28 @@ public interface Resources {
    @POST
    @Path("/reset")
    Operation resetInstance(@EndpointParam URI selfLink);
+
+   /**
+    * This method starts an instance that was stopped using the using the {@link #stop(String)} method.
+    * @param instance - name of the instance to be started
+    */
+   @Named("Instances:start")
+   @POST
+   @Path("/start")
+   @Produces(APPLICATION_JSON)
+   Operation startInstance(@EndpointParam URI selfLink);
+
+   /**
+    * This method stops a running instance, shutting it down cleanly, and allows you to restart
+    *  the instance at a later time. Stopped instances do not incur per-minute, virtual machine
+    *  usage charges while they are stopped, but any resources that the virtual machine is using,
+    *  such as persistent disks and static IP addresses,will continue to be charged until they are deleted.
+    * @param instance
+    * @return
+    */
+   @Named("Instances:stop")
+   @POST
+   @Path("/stop")
+   @Produces(APPLICATION_JSON)
+   Operation stopInstance(@EndpointParam URI selfLink);
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceLiveTest.java
@@ -77,14 +77,54 @@ public class GoogleComputeEngineServiceLiveTest extends BaseComputeServiceLiveTe
    public void testCorrectAuthException() throws Exception {
    }
 
-   // reboot is not supported by GCE
-   @Test(enabled = true, dependsOnMethods = "testGet")
-   public void testReboot() throws Exception {
+   @Test(enabled = true)
+   public void testCompareSizes() throws Exception {
+      super.testCompareSizes();
    }
 
-   // suspend/Resume is not supported by GCE
+   @Test(enabled = true, dependsOnMethods = {"testCompareSizes"})
+   public void testAScriptExecutionAfterBootWithBasicTemplate() throws Exception {
+      super.testAScriptExecutionAfterBootWithBasicTemplate();
+   }
+
+   @Test(enabled = true, dependsOnMethods = {"testCompareSizes"})
+   public void testConcurrentUseOfComputeServiceToCreateNodes() throws Exception {
+      super.testConcurrentUseOfComputeServiceToCreateNodes();
+   }
+
+   @Test(enabled = true, dependsOnMethods = {"testConcurrentUseOfComputeServiceToCreateNodes"})
+   public void testCreateTwoNodesWithRunScript() throws Exception {
+      super.testCreateTwoNodesWithRunScript();
+   }
+
+   @Test(enabled = true, dependsOnMethods = {"testCreateAnotherNodeWithANewContextToEnsureSharedMemIsntRequired"})
+   public void testCredentialsCache() throws Exception {
+      super.testCredentialsCache();
+   }
+
+   @Test(enabled = true, dependsOnMethods = {"testCreateTwoNodesWithRunScript"})
+   public void testCreateTwoNodesWithOneSpecifiedName() throws Exception {
+      super.testCreateTwoNodesWithOneSpecifiedName();
+   }
+
+   @Test(enabled = true, dependsOnMethods = {"testCreateTwoNodesWithOneSpecifiedName"})
+   public void testCreateAnotherNodeWithANewContextToEnsureSharedMemIsntRequired() throws Exception {
+      super.testCreateAnotherNodeWithANewContextToEnsureSharedMemIsntRequired();
+   }
+
+   @Test(enabled = true, dependsOnMethods = {"testCreateAnotherNodeWithANewContextToEnsureSharedMemIsntRequired"})
+   public void testGet() throws Exception {
+      super.testGet();
+   }
+
+   @Test(enabled = true, dependsOnMethods = {"testGet"})
+   public void testReboot() throws Exception {
+      super.testReboot();
+   }
+
    @Test(enabled = true, dependsOnMethods = "testReboot")
    public void testSuspendResume() throws Exception {
+      super.testSuspendResume();
    }
 
    @Test(enabled = true, dependsOnMethods = "testSuspendResume")


### PR DESCRIPTION
Not sure why these were still unimplemented, since stop/start has been
in GCE for ages. Probably my bad. =) Anyway, unit tests pass, live
tests...run? Took a bunch of work to get them to actually launch,
which was odd.