### PR TITLE
Update ComposeObjectTemplate and update MockTests

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/strategy/internal/SequentialMultipartUploadStrategy.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/strategy/internal/SequentialMultipartUploadStrategy.java
@@ -87,7 +87,9 @@ public final class SequentialMultipartUploadStrategy extends MultipartUploadStra
 
             sourceList.add(object);
          }
-         ComposeObjectTemplate template = ComposeObjectTemplate.create(sourceList, destination);
+         ComposeObjectTemplate template = ComposeObjectTemplate.builder().fromGoogleCloudStorageObject(sourceList)
+               .destination(destination).build();
+
          return api.getObjectApi().composeObjects(container, key, template).etag();
       } else {
          return api.getObjectApi()

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/ComposeObjectTemplate.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/templates/ComposeObjectTemplate.java
@@ -14,25 +14,110 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jclouds.googlecloudstorage.domain.templates;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.jclouds.googlecloudstorage.domain.GoogleCloudStorageObject;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
 @AutoValue
 public abstract class ComposeObjectTemplate {
 
-   private final String kind = "storage/composeRequest";
+   @AutoValue
+   public abstract static class SourceObject {
 
-   public abstract List<GoogleCloudStorageObject> sourceObjects();
+      @AutoValue
+      public abstract static class ObjectPreconditions {
+         @Nullable public abstract long ifGenerationMatch();
 
+         @SerializedNames({"ifGenerationMatch"})
+         public static ObjectPreconditions create(long ifGenerationMatch){
+            return new AutoValue_ComposeObjectTemplate_SourceObject_ObjectPreconditions(ifGenerationMatch);
+         }
+
+         ObjectPreconditions(){
+         }
+      }
+
+      public abstract String name();
+      @Nullable public abstract Long generation();
+      @Nullable public abstract ObjectPreconditions objectPreconditions();
+
+      public static SourceObject nameOnly(String name){
+         return create(name, null, null);
+      }
+
+      public static SourceObject createWithPrecondition(String name, Long generation, Long objectPreconditions){
+         return create(name, generation, ObjectPreconditions.create(objectPreconditions));
+      }
+
+      @SerializedNames({ "name", "generation", "objectPreconditions"})
+      public static SourceObject create(String name, @Nullable Long generation,
+            @Nullable ObjectPreconditions objectPreconditions) {
+         return new AutoValue_ComposeObjectTemplate_SourceObject(name, generation, objectPreconditions);
+      }
+
+      SourceObject(){
+      }
+   }
+
+   public abstract List<SourceObject> sourceObjects();
    public abstract ObjectTemplate destination();
 
-   public static ComposeObjectTemplate create(List<GoogleCloudStorageObject> sourceObjects, ObjectTemplate destination) {
+   @SerializedNames({"sourceObjects", "destination"})
+   public static ComposeObjectTemplate create(List<SourceObject> sourceObjects, ObjectTemplate destination) {
       return new AutoValue_ComposeObjectTemplate(sourceObjects, destination);
+   }
+
+   public static Builder builder(){
+      return new Builder();
+   }
+
+   ComposeObjectTemplate() {
+   }
+
+   public static class Builder {
+      private ImmutableList<SourceObject> sourceObjects;
+      private ObjectTemplate destination;
+
+      Builder() {
+      }
+
+      public Builder fromGoogleCloudStorageObject(Collection<GoogleCloudStorageObject> objects) {
+         ImmutableList.Builder<SourceObject> sourceObjects = new ImmutableList.Builder<ComposeObjectTemplate.SourceObject>();
+         for (GoogleCloudStorageObject obj : objects) {
+            sourceObjects.add(SourceObject.createWithPrecondition(obj.name(), obj.generation(), obj.generation()));
+         }
+         this.sourceObjects = sourceObjects.build();
+         return this;
+      }
+
+      public Builder fromNames(List<String> SourceObjectNames) {
+         ArrayList<SourceObject> sourceObjects = new ArrayList<SourceObject>();
+         for (String name : SourceObjectNames) {
+            sourceObjects.add(SourceObject.nameOnly(name));
+         }
+         this.sourceObjects = ImmutableList.copyOf(sourceObjects);
+         return this;
+      }
+
+      public Builder destination(ObjectTemplate destination) {
+         checkNotNull(destination, "destination");
+         this.destination = destination;
+         return this;
+      }
+
+      public ComposeObjectTemplate build() {
+         return ComposeObjectTemplate.create(sourceObjects, destination);
+      }
    }
 }

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiLiveTest.java
@@ -255,7 +255,10 @@ public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
       sourceList.add(api().getObject(BUCKET_NAME2, UPLOAD_OBJECT_NAME));
       sourceList.add(api().getObject(BUCKET_NAME2, COPIED_OBJECT_NAME));
 
-      ComposeObjectTemplate requestTemplate = ComposeObjectTemplate.create(sourceList, destination);
+      ComposeObjectTemplate requestTemplate = ComposeObjectTemplate.builder()
+         .fromGoogleCloudStorageObject(sourceList)
+         .destination(destination)
+         .build();
 
       GoogleCloudStorageObject gcsObject = api().composeObjects(BUCKET_NAME2, COMPOSED_OBJECT, requestTemplate);
 
@@ -273,8 +276,10 @@ public class ObjectApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
       sourceList.add(api().getObject(BUCKET_NAME2, UPLOAD_OBJECT_NAME));
       sourceList.add(api().getObject(BUCKET_NAME2, COPIED_OBJECT_NAME));
 
-      ComposeObjectTemplate requestTemplate = ComposeObjectTemplate.create(sourceList, destination);
-
+      ComposeObjectTemplate requestTemplate =  ComposeObjectTemplate.builder()
+         .fromGoogleCloudStorageObject(sourceList)
+         .destination(destination)
+         .build();
       ComposeObjectOptions options = new ComposeObjectOptions().destinationPredefinedAcl(
                DestinationPredefinedAcl.BUCKET_OWNER_READ).ifMetagenerationNotMatch(RANDOM_LONG);
 

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
@@ -176,8 +176,9 @@ public class ObjectApiMockTest extends BaseGoogleCloudStorageApiMockTest {
 
       ObjectTemplate template = new ObjectTemplate().name("file_name").size((long) 1000).crc32c("crc32c");
 
-      ComposeObjectTemplate composeTemplate = ComposeObjectTemplate.create(
-            new ParseGoogleCloudStorageObjectListTest().expected(), template);
+      ComposeObjectTemplate composeTemplate = ComposeObjectTemplate.builder()
+      .fromGoogleCloudStorageObject(new ParseGoogleCloudStorageObjectListTest().expected())
+      .destination(template).build();
 
       assertEquals(objectApi().composeObjects("destination_bucket", "destination_object", composeTemplate),
             new ParseGoogleCloudStorageObject().expected());
@@ -189,8 +190,9 @@ public class ObjectApiMockTest extends BaseGoogleCloudStorageApiMockTest {
       server.enqueue(jsonResponse("/object_get.json"));
 
       ObjectTemplate template = new ObjectTemplate().name("file_name").size((long) 1000).crc32c("crc32c");
-      ComposeObjectTemplate composeTemplate = ComposeObjectTemplate.create(
-            new ParseGoogleCloudStorageObjectListTest().expected(), template);
+      ComposeObjectTemplate composeTemplate = ComposeObjectTemplate.builder()
+      .fromGoogleCloudStorageObject(new ParseGoogleCloudStorageObjectListTest().expected())
+      .destination(template).build();
 
       ComposeObjectOptions options = new ComposeObjectOptions()
          .destinationPredefinedAcl(DestinationPredefinedAcl.BUCKET_OWNER_FULLCONTROL)

--- a/google-cloud-storage/src/test/resources/object_compose_request.json
+++ b/google-cloud-storage/src/test/resources/object_compose_request.json
@@ -1,54 +1,23 @@
 {
   "sourceObjects": [
     {
-      "id": "test/file_name/1000",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/test/o/file_name",
-      "etag": "etag",
       "name": "file_name",
-      "bucket": "test",
       "generation": 1000,
-      "metageneration": 8,
-      "contentType": "application/x-tar",
-      "updated": "2014-09-27T00:01:44.819Z",
-      "storageClass": "STANDARD",
-      "size": 1000,
-      "md5Hash": "md5Hash",
-      "mediaLink": "https://www.googleapis.com/download/storage/v1/b/test/o/file_name?generation=1000&alt=media",
-      "metadata": {},
-      "acl": [],
-      "owner": {
-        "entity": "entity",
-        "entityId": "entityId"
-      },
-      "crc32c": "crc32c"
+      "objectPreconditions": {
+        "ifGenerationMatch": 1000
+      }
     },
     {
-      "id": "test/file_name2/1000",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/test/o/file_name2",
-      "etag": "etag",
       "name": "file_name2",
-      "bucket": "test",
       "generation": 1001,
-      "metageneration": 9,
-      "contentType": "image/png",
-      "updated": "2014-09-27T00:01:44.819Z",
-      "storageClass": "STANDARD",
-      "size": 10,
-      "md5Hash": "md5Hash",
-      "mediaLink": "https://www.googleapis.com/download/storage/v1/b/test/o/file_name2?generation=1001&alt=media",
-      "metadata": {},
-      "acl": [],
-      "owner": {
-        "entity": "entity",
-        "entityId": "entityId"
-      },
-      "crc32c": "crc32c"
+      "objectPreconditions": {
+        "ifGenerationMatch": 1001
+      }
     }
   ],
   "destination": {
     "name": "file_name",
     "size": 1000,
     "crc32c": "crc32c"
-  },
-  "kind": "storage/composeRequest"
+  }
 }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiLiveTest.java
@@ -44,7 +44,7 @@ import com.google.inject.TypeLiteral;
 public class BaseGoogleComputeEngineApiLiveTest extends BaseApiLiveTest<GoogleComputeEngineApi> {
 
    protected static final String ZONE_API_URL_SUFFIX = "/zones/";
-   protected static final String DEFAULT_ZONE_NAME = "us-central1-a";
+   protected static final String DEFAULT_ZONE_NAME = "us-central1-f";
    protected static final String DEFAULT_REGION_NAME = "us-central1";
    protected static final String NETWORK_API_URL_SUFFIX = "/global/networks/";
    protected static final String MACHINE_TYPE_API_URL_SUFFIX = "/machineTypes/";


### PR DESCRIPTION
This change will make implementing the blobstore multipart uploads using simple uploads and compose much cleaner.  