### PR TITLE
Update ObjectApi and getBlob, fix testGetRangeOutOfRange

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
@@ -113,7 +113,8 @@ public interface ObjectApi {
     * @param objectName
     *           Name of the object
     * @param options
-    *           Supply {@link GetObjectOptions} with optional query parameters
+    *           A class that implements {@link HttpRequestOptions}
+    *           such as {@link GetObjectOptions} with optional query parameters
     *
     * @return a {@link GoogleCloudStorageObject}
     */
@@ -153,7 +154,8 @@ public interface ObjectApi {
     * @param objectName
     *           Name of the object
     * @param options
-    *           Supply {@link GetObjectOptions} with optional query parameters
+    *           A class that implements {@link HttpRequestOptions}
+    *           such as {@link GetObjectOptions} with optional query parameters
     *
     * @return a {@link GoogleCloudStorageObject}
     */

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
@@ -45,6 +45,7 @@ import org.jclouds.googlecloudstorage.options.InsertObjectOptions;
 import org.jclouds.googlecloudstorage.options.ListObjectOptions;
 import org.jclouds.googlecloudstorage.options.UpdateObjectOptions;
 import org.jclouds.googlecloudstorage.parser.ParseToPayloadEnclosing;
+import org.jclouds.http.options.HttpRequestOptions;
 import org.jclouds.io.Payload;
 import org.jclouds.io.PayloadEnclosing;
 import org.jclouds.javax.annotation.Nullable;
@@ -123,7 +124,7 @@ public interface ObjectApi {
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    GoogleCloudStorageObject getObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-            GetObjectOptions options);
+         HttpRequestOptions options);
 
    /**
     * Retrieve an object or their metadata
@@ -163,7 +164,7 @@ public interface ObjectApi {
    @ResponseParser(ParseToPayloadEnclosing.class)
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable PayloadEnclosing download(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-            GetObjectOptions options);
+         HttpRequestOptions options);
 
    /**
     * Stores a new object. Object metadata setting is not supported with simple uploads

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/options/GetObjectOptions.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/options/GetObjectOptions.java
@@ -19,12 +19,12 @@ package org.jclouds.googlecloudstorage.options;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.jclouds.googlecloudstorage.domain.DomainResourceReferences.Projection;
-import org.jclouds.http.options.BaseHttpRequestOptions;
+import org.jclouds.http.options.GetOptions;
 
 /**
  * Allows to optionally specify generation,ifGenerationMatch,ifGenerationNotMatch, ifMetagenerationMatch,ifMetagenerationNotMatch and projection which used in Bucket
  */
-public class GetObjectOptions extends BaseHttpRequestOptions {
+public class GetObjectOptions extends GetOptions {
 
    public GetObjectOptions ifGenerationMatch(Long ifGenerationMatch) {
       this.queryParameters.put("ifGenerationMatch", checkNotNull(ifGenerationMatch, "ifGenerationMatch") + "");

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/options/GetObjectOptions.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/options/GetObjectOptions.java
@@ -22,7 +22,8 @@ import org.jclouds.googlecloudstorage.domain.DomainResourceReferences.Projection
 import org.jclouds.http.options.GetOptions;
 
 /**
- * Allows to optionally specify generation,ifGenerationMatch,ifGenerationNotMatch, ifMetagenerationMatch,ifMetagenerationNotMatch and projection which used in Bucket
+ * Allows to optionally specify generation, ifGenerationMatch, ifGenerationNotMatch, ifMetagenerationMatch,
+ * ifMetagenerationNotMatch and projection, in addition to the values in {@link GetOptions}.
  */
 public class GetObjectOptions extends GetOptions {
 

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
@@ -81,10 +81,12 @@ public class ObjectApiMockTest extends BaseGoogleCloudStorageApiMockTest {
       server.enqueue(jsonResponse("/object_get.json"));
 
       GetObjectOptions options = new GetObjectOptions().ifGenerationMatch((long) 1000);
+      options.range(0, 1023);
 
       assertEquals(objectApi().getObject("test", "file_name", options),
             new ParseGoogleCloudStorageObject().expected());
-      assertSent(server, "GET", "/storage/v1/b/test/o/file_name?ifGenerationMatch=1000");
+      RecordedRequest request = assertSent(server, "GET", "/storage/v1/b/test/o/file_name?ifGenerationMatch=1000");
+      assertEquals(request.getHeader("Range"), "bytes=0-1023");
    }
 
    public void simpleUpload() throws Exception {


### PR DESCRIPTION
This uncovers a new test failure `BaseBlobIntegrationTest#testGetIfMatch`

testGetIfMatch was not actually testing the intended behavior. Neither request was attaching a If-Match header and the test was passing just fine. 

Now it is attaching an If-Match header but with quotes around the etag causing the request to be rejected. 

