### PR TITLE
Image credentials and project improvements

### DIFF
--- a/google-compute-engine/README.md
+++ b/google-compute-engine/README.md
@@ -6,7 +6,7 @@ Authenticating into the instances:
 --------
 
 User:
-If no user is provided in GoogleComputeEngineTemplateOptions when launching an instance by default "root" is used.
+If no user is specified in the template options when launching instances, the default one will be used: "jclouds" for all instances, "core" for CoreOS images, and "Administrator" for Windows images.
 
 Credential:
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineApiMetadata.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/GoogleComputeEngineApiMetadata.java
@@ -62,9 +62,9 @@ public class GoogleComputeEngineApiMetadata extends BaseHttpApiMetadata<GoogleCo
       properties.put(PROPERTY_SESSION_INTERVAL, 3600);
       properties.put(OPERATION_COMPLETE_INTERVAL, 500);
       properties.put(OPERATION_COMPLETE_TIMEOUT, 600000);
-      properties.put(TEMPLATE, "osFamily=DEBIAN,osVersionMatches=7\\..*,locationId=us-central1-a,loginUser=jclouds");
+      properties.put(TEMPLATE, "osFamily=DEBIAN,osVersionMatches=7\\..*,locationId=us-central1-a");
       properties.put(PROJECT_NAME, ""); // Defaulting to empty helps avoid temptation for optional inject!
-      properties.put(IMAGE_PROJECTS, "centos-cloud,debian-cloud,rhel-cloud,suse-cloud,opensuse-cloud,gce-nvme,coreos-cloud");
+      properties.put(IMAGE_PROJECTS, "centos-cloud,debian-cloud,rhel-cloud,suse-cloud,opensuse-cloud,gce-nvme,coreos-cloud,ubuntu-os-cloud,windows-cloud");
       return properties;
    }
 

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
@@ -39,14 +39,18 @@ import org.jclouds.compute.ComputeServiceAdapter;
 import org.jclouds.compute.config.ComputeServiceAdapterContextModule;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.OperatingSystem;
+import org.jclouds.compute.domain.OsFamily;
 import org.jclouds.compute.extensions.ImageExtension;
 import org.jclouds.compute.extensions.SecurityGroupExtension;
 import org.jclouds.compute.options.TemplateOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.domain.LoginCredentials;
 import org.jclouds.googlecomputeengine.compute.GoogleComputeEngineService;
 import org.jclouds.googlecomputeengine.compute.GoogleComputeEngineServiceAdapter;
 import org.jclouds.googlecomputeengine.compute.functions.FirewallTagNamingConvention;
 import org.jclouds.googlecomputeengine.compute.functions.GoogleComputeEngineImageToImage;
+import org.jclouds.googlecomputeengine.compute.functions.ImageNameToOperatingSystem;
 import org.jclouds.googlecomputeengine.compute.functions.InstanceToNodeMetadata;
 import org.jclouds.googlecomputeengine.compute.functions.MachineTypeToHardware;
 import org.jclouds.googlecomputeengine.compute.functions.OrphanedGroupsFromDeadNodes;
@@ -113,6 +117,9 @@ public final class GoogleComputeEngineServiceContextModule
 
       bind(new TypeLiteral<Predicate<String>>() {
       }).to(GroupIsEmpty.class);
+      
+      bind(new TypeLiteral<Function<String, OperatingSystem>>() {
+      }).to(ImageNameToOperatingSystem.class);
 
       bind(FirewallTagNamingConvention.Factory.class).in(Scopes.SINGLETON);
       bindHttpApi(binder(), Resources.class);
@@ -158,6 +165,27 @@ public final class GoogleComputeEngineServiceContextModule
             return result.build();
          }
       }, seconds, SECONDS);
+   }
+   
+   @Override
+   protected Map<OsFamily, LoginCredentials> osFamilyToCredentials(Injector injector) {
+      // GCE does not enable the 'root' account for ssh access by default, but it will create a privileged
+      // user when the SSH key is provided. Populate the map to use 'jclouds' as a default user.
+      ImmutableMap.Builder<OsFamily, LoginCredentials> builder = ImmutableMap.builder();
+      for (OsFamily family : OsFamily.values()) {
+         switch (family) {
+            case COREOS:
+               builder.put(family, LoginCredentials.builder().user("core").build());
+               break;
+            case WINDOWS:
+               builder.put(family, LoginCredentials.builder().user("Administrator").build());
+               break;
+            default:
+               builder.put(family, LoginCredentials.builder().user("jclouds").build());
+               break;
+         }
+      }
+      return builder.build();
    }
 
    @Override protected Optional<ImageExtension> provideImageExtension(Injector i) {

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/ImageNameToOperatingSystem.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/ImageNameToOperatingSystem.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.compute.functions;
+
+import static com.google.common.base.Joiner.on;
+import static com.google.common.collect.Iterables.limit;
+import static com.google.common.collect.Iterables.skip;
+
+import java.util.List;
+
+import org.jclouds.compute.domain.OperatingSystem;
+import org.jclouds.compute.domain.OsFamily;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+public class ImageNameToOperatingSystem implements Function<String, OperatingSystem> {
+
+   @Override public OperatingSystem apply(String input) {
+      // Remove the backport prefix before parsing the name
+      String name = input.contains("backports") ? input.substring(input.indexOf("backports-") + 10) : input;
+      
+      OperatingSystem.Builder builder = defaultOperatingSystem(name);
+      List<String> splits = Lists.newArrayList(name.split("-"));
+      if (splits == null || splits.size() == 0 || splits.size() < 3) {
+         return builder.build();
+      }
+
+      // GCE namings that don't match the OsFamily enum
+      String os = splits.get(0);
+      if ("opensuse".equals(os) || "sles".equals(os)) {
+         builder.family(OsFamily.SUSE);
+      } else {
+         OsFamily family = OsFamily.fromValue(os);
+         if (family != OsFamily.UNRECOGNIZED) {
+            builder.family(family);
+         }
+      }
+
+      // TODO: Improve the version parsing so it is more portable
+      String version = on(".").join(limit(skip(splits, 1), splits.size() - 2));
+      builder.version(version);
+
+      return builder.build();
+   }
+   
+   private OperatingSystem.Builder defaultOperatingSystem(String name) {
+      return OperatingSystem.builder().family(OsFamily.LINUX).is64Bit(true).description(name);
+   }
+
+}

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineTemplateBuilderLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineTemplateBuilderLiveTest.java
@@ -59,7 +59,6 @@ public class GoogleComputeEngineTemplateBuilderLiveTest extends BaseTemplateBuil
       Map<OsFamily, String> defaultUsernames = ImmutableMap.of(COREOS, "core", WINDOWS, "Administrator");
       Set<? extends Image> images = view.getComputeService().listImages();
       for (Image image : images) {
-         System.err.println(image);
          assertEquals(image.getDefaultCredentials().getUser(),
                firstNonNull(defaultUsernames.get(image.getOperatingSystem().getFamily()), "jclouds"));
       }

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineTemplateBuilderLiveTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineTemplateBuilderLiveTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.compute;
+
+import static com.google.common.base.Objects.firstNonNull;
+import static org.jclouds.compute.domain.OsFamily.COREOS;
+import static org.jclouds.compute.domain.OsFamily.DEBIAN;
+import static org.jclouds.compute.domain.OsFamily.WINDOWS;
+import static org.jclouds.compute.util.ComputeServiceUtils.getCores;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import org.jclouds.compute.domain.Image;
+import org.jclouds.compute.domain.OsFamily;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.internal.BaseTemplateBuilderLiveTest;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+@Test(groups = "live", testName = "GoogleComputeEngineTemplateBuilderLiveTest")
+public class GoogleComputeEngineTemplateBuilderLiveTest extends BaseTemplateBuilderLiveTest {
+
+   public GoogleComputeEngineTemplateBuilderLiveTest() {
+      provider = "google-compute-engine";
+   }
+   
+   @Test
+   @Override
+   public void testDefaultTemplateBuilder() throws IOException {
+      Template defaultTemplate = view.getComputeService().templateBuilder().build();
+      assertTrue(defaultTemplate.getImage().getOperatingSystem().getVersion().equals("7.wheezy"));
+      assertEquals(defaultTemplate.getImage().getOperatingSystem().is64Bit(), true);
+      assertEquals(defaultTemplate.getImage().getOperatingSystem().getFamily(), DEBIAN);
+      assertEquals(getCores(defaultTemplate.getHardware()), 1.0d);
+   }
+   
+   @Test
+   public void testDefaultCredentials() {
+      Map<OsFamily, String> defaultUsernames = ImmutableMap.of(COREOS, "core", WINDOWS, "Administrator");
+      Set<? extends Image> images = view.getComputeService().listImages();
+      for (Image image : images) {
+         System.err.println(image);
+         assertEquals(image.getDefaultCredentials().getUser(),
+               firstNonNull(defaultUsernames.get(image.getOperatingSystem().getFamily()), "jclouds"));
+      }
+   }
+   
+   @Override
+   protected Set<String> getIso3166Codes() {
+      return ImmutableSet.<String> of();
+   }
+
+}

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/GoogleComputeEngineImageToImageTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/GoogleComputeEngineImageToImageTest.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableList;
 @Test(groups = "unit", testName = "GoogleComputeEngineImageToImageTest")
 public class GoogleComputeEngineImageToImageTest {
    public void testArbitraryImageName() {
-      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage();
+      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage(new ImageNameToOperatingSystem());
       Image image = image("arbitratyname", null);
       org.jclouds.compute.domain.Image transformed = imageToImage.apply(image);
       assertEquals(transformed.getName(), image.name());
@@ -44,7 +44,7 @@ public class GoogleComputeEngineImageToImageTest {
    }
 
    public void testWellFormedImageName() {
-      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage();
+      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage(new ImageNameToOperatingSystem());
       Image image = image("ubuntu-12-04-v123123", null);
       org.jclouds.compute.domain.Image transformed = imageToImage.apply(image);
       assertEquals(transformed.getName(), image.name());
@@ -55,7 +55,7 @@ public class GoogleComputeEngineImageToImageTest {
    }
 
    public void testDeleted(){
-      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage();
+      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage(new ImageNameToOperatingSystem());
       Deprecated deprecated =  Deprecated.create(
          State.DELETED, // state
          URI.create("http://baseurl/projects/centos-cloud/global/images/centos-6-2-v20120326test"), // replacement
@@ -73,7 +73,7 @@ public class GoogleComputeEngineImageToImageTest {
    }
 
    public void testDeprecated(){
-      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage();
+      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage(new ImageNameToOperatingSystem());
       Deprecated deprecated =  Deprecated.create(
          State.DEPRECATED, // state
          URI.create("http://baseurl/projects/centos-cloud/global/images/centos-6-2-v20120326test"), // replacement

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/ImageNameToOperatingSystemTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/ImageNameToOperatingSystemTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.compute.functions;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.jclouds.compute.domain.OperatingSystem;
+import org.jclouds.compute.domain.OsFamily;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "ImageNameToOperatingSystemTest")
+public class ImageNameToOperatingSystemTest {
+   
+   private final ImageNameToOperatingSystem function = new ImageNameToOperatingSystem();
+   
+   public void testVersions() {
+      assertVersion("centos-6-v20150603", OsFamily.CENTOS, "6");
+      assertVersion("coreos-stable-681-0-0-v20150609", OsFamily.COREOS, "stable.681.0.0");
+      assertVersion("debian-7-wheezy-v20150603", OsFamily.DEBIAN, "7.wheezy");
+      assertVersion("backports-debian-7-wheezy-v20150603", OsFamily.DEBIAN, "7.wheezy");
+      assertVersion("nvme-backports-debian-7-wheezy-v20140904", OsFamily.DEBIAN, "7.wheezy");
+      assertVersion("opensuse-13-1-v20150515", OsFamily.SUSE, "13.1");
+      assertVersion("rhel-6-v20150603", OsFamily.RHEL, "6");
+      assertVersion("sles-11-sp3-v20150511", OsFamily.SUSE, "11.sp3");
+      assertVersion("sles-12-v20150511", OsFamily.SUSE, "12");
+      assertVersion("ubuntu-1204-precise-v20150316", OsFamily.UBUNTU, "1204.precise");
+      assertVersion("windows-server-2008-r2-dc-v20150511", OsFamily.WINDOWS, "server.2008.r2.dc");
+   }
+
+   private void assertVersion(String name, OsFamily family, String version) {
+      OperatingSystem result = function.apply(name);
+      assertEquals(result.getFamily(), family);
+      assertEquals(result.getVersion(), version);
+      assertTrue(result.is64Bit());
+   }
+   
+}


### PR DESCRIPTION
This fixes several issues. It improves the OsFamily detection and properly sets a default username for each image so the SSH access works on them out of the box.

[JCLOUDS-870](https://issues.apache.org/jira/browse/JCLOUDS-870): Adds the missing projects to the default project list
[JCLOUDS-861](https://issues.apache.org/jira/browse/JCLOUDS-861) & [JCLOUDS-911](https://issues.apache.org/jira/browse/JCLOUDS-911): Improved the way image OSFamily is parsed and
configured the default username for each image type.

/cc @danbroudy 