### PR TITLE
JCLOUDS-935. Move AttachDisk.InitializeParams to URI for diskType

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/AttachDisk.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/AttachDisk.java
@@ -37,14 +37,14 @@ public abstract class AttachDisk {
       /** The {@link org.jclouds.googlecomputeengine.domain.Image#selfLink() source image}. */
       public abstract URI sourceImage();
 
-      @Nullable public abstract String diskType();
+      @Nullable public abstract URI diskType();
 
       static InitializeParams create(URI sourceImage) {
          return create(null, null, sourceImage, null);
       }
 
       @SerializedNames({ "diskName", "diskSizeGb", "sourceImage", "diskType" })
-      public static InitializeParams create(String diskName, Long diskSizeGb, URI sourceImage, String diskType) {
+      public static InitializeParams create(String diskName, Long diskSizeGb, URI sourceImage, URI diskType) {
          return new AutoValue_AttachDisk_InitializeParams(diskName, diskSizeGb, sourceImage, diskType);
       }
 

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiMockTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/features/InstanceApiMockTest.java
@@ -195,7 +195,7 @@ public class InstanceApiMockTest extends BaseGoogleComputeEngineApiMockTest {
                                            "test", // diskName
                                            Long.parseLong("100", 10), // diskSizeGb
                                            URI.create(url("/projects/party/global/images/test")), // sourceImage
-                                           "pd-standard" // diskType
+                                           URI.create(url("/projects/party/zones/us-central1-a/diskTypes/pd-standard")) // diskType
                                            ), // initializeParams
                                      true, // autoDelete
                                      ImmutableList.of(url("/projects/suse-cloud/global/licenses/sles-12")), // licenses

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/parse/ParseInstanceTest.java
@@ -18,23 +18,21 @@ package org.jclouds.googlecomputeengine.parse;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import javax.ws.rs.Consumes;
 import java.net.URI;
 
-import javax.ws.rs.Consumes;
-
+import com.google.common.collect.ImmutableList;
 import org.jclouds.googlecomputeengine.domain.AttachDisk;
 import org.jclouds.googlecomputeengine.domain.AttachDisk.DiskInterface;
 import org.jclouds.googlecomputeengine.domain.Instance;
 import org.jclouds.googlecomputeengine.domain.Instance.AttachedDisk;
 import org.jclouds.googlecomputeengine.domain.Instance.NetworkInterface;
-import org.jclouds.googlecomputeengine.domain.Instance.ServiceAccount;
 import org.jclouds.googlecomputeengine.domain.Instance.Scheduling.OnHostMaintenance;
+import org.jclouds.googlecomputeengine.domain.Instance.ServiceAccount;
 import org.jclouds.googlecomputeengine.domain.Metadata;
 import org.jclouds.googlecomputeengine.domain.Tags;
 import org.jclouds.googlecomputeengine.internal.BaseGoogleComputeEngineParseTest;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 @Test(groups = "unit", testName = "ParseInstanceTest")
 public class ParseInstanceTest extends BaseGoogleComputeEngineParseTest<Instance> {
@@ -81,7 +79,7 @@ public class ParseInstanceTest extends BaseGoogleComputeEngineParseTest<Instance
                         "test", // diskName
                         Long.parseLong("100", 10), // diskSizeGb
                         URI.create(baseUrl + "/party/global/images/test"), // sourceImage
-                        "pd-standard" // diskType
+                        URI.create(baseUrl + "/party/zones/us-central1-a/diskTypes/pd-standard") // diskType
                         ), // initializeParams
                   ImmutableList.of(baseUrl + "/suse-cloud/global/licenses/sles-12"), // licenses
                   DiskInterface.NVME // interface

--- a/google-compute-engine/src/test/resources/instance_attach_disk.json
+++ b/google-compute-engine/src/test/resources/instance_attach_disk.json
@@ -9,7 +9,7 @@
     "diskName": "test",
     "sourceImage": "https://www.googleapis.com/compute/v1/projects/party/global/images/test",
     "diskSizeGb": 100,
-    "diskType": "pd-standard"
+    "diskType": "https://www.googleapis.com/compute/v1/projects/party/zones/us-central1-a/diskTypes/pd-standard"
   },
   "licenses": [
     "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-12"

--- a/google-compute-engine/src/test/resources/instance_get.json
+++ b/google-compute-engine/src/test/resources/instance_get.json
@@ -30,7 +30,7 @@
             "diskName": "test",
             "sourceImage": "https://www.googleapis.com/compute/v1/projects/party/global/images/test",
             "diskSizeGb": "100",
-            "diskType": "pd-standard"
+            "diskType": "https://www.googleapis.com/compute/v1/projects/party/zones/us-central1-a/diskTypes/pd-standard"
          },
          "licenses": [
             "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-12"

--- a/google-compute-engine/src/test/resources/instance_list.json
+++ b/google-compute-engine/src/test/resources/instance_list.json
@@ -35,7 +35,7 @@
             "diskName": "test",
             "sourceImage": "https://www.googleapis.com/compute/v1/projects/party/global/images/test",
             "diskSizeGb": "100",
-            "diskType": "pd-standard"
+            "diskType": "https://www.googleapis.com/compute/v1/projects/party/zones/us-central1-a/diskTypes/pd-standard"
           },
           "licenses": [
             "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-12"


### PR DESCRIPTION
Note that two tests are failing right now with or without this.