### PR TITLE
JCLOUDS-930: Skip the prefix test in GCS.

### DIFF
--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerLiveTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 
 import org.jclouds.blobstore.integration.internal.BaseContainerLiveTest;
 import org.jclouds.googlecloud.internal.TestProperties;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 @Test(groups = { "live" })
@@ -32,5 +33,10 @@ public class GoogleCloudStorageContainerLiveTest extends BaseContainerLiveTest {
    @Override protected Properties setupProperties() {
       TestProperties.setGoogleCredentialsFromJson(provider);
       return TestProperties.apply(provider, super.setupProperties());
+   }
+
+   @Override
+   public void testContainerListWithPrefix() {
+      throw new SkipException("Prefix option has not been plumbed down to GCS");
    }
 }


### PR DESCRIPTION
As the prefix option has not been plumbed down into GCS, we should
skip the prefix test.