### PR TITLE
Move the skipped tests.

### DIFF
--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerIntegrationLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerIntegrationLiveTest.java
@@ -105,4 +105,14 @@ public class GoogleCloudStorageContainerIntegrationLiveTest extends BaseContaine
    public void testListMarkerAfterLastKey() throws Exception {
       throw new SkipException("cannot specify arbitrary markers");
    }
+
+   @Override
+   public void testContainerListWithPrefix() {
+      throw new SkipException("Prefix option has not been plumbed down to GCS");
+   }
+
+   @Override
+   public void testDelimiterList() {
+      throw new SkipException("Prefix option has not been plumbed down to GCS");
+   }
 }

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerLiveTest.java
@@ -20,7 +20,6 @@ import java.util.Properties;
 
 import org.jclouds.blobstore.integration.internal.BaseContainerLiveTest;
 import org.jclouds.googlecloud.internal.TestProperties;
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 @Test(groups = { "live" })
@@ -33,15 +32,5 @@ public class GoogleCloudStorageContainerLiveTest extends BaseContainerLiveTest {
    @Override protected Properties setupProperties() {
       TestProperties.setGoogleCredentialsFromJson(provider);
       return TestProperties.apply(provider, super.setupProperties());
-   }
-
-   @Override
-   public void testContainerListWithPrefix() {
-      throw new SkipException("Prefix option has not been plumbed down to GCS");
-   }
-
-   @Override
-   public void testDelimiterList() {
-      throw new SkipException("Prefix option has not been plumbed down to GCS");
    }
 }


### PR DESCRIPTION
Since the delimiter and prefix tests were moved to
BaseContainerIntegrationTest (from BaseContainerLiveTest), need to do
the same for google.