### PR TITLE
JCLOUDS-992: do not use RELATIVE_PATH for BLOBs.

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobStore.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobStore.java
@@ -187,21 +187,15 @@ public final class GoogleCloudStorageBlobStore extends BaseBlobStore {
    /** Returns list of of all the objects */
    @Override
    public PageSet<? extends StorageMetadata> list(String container) {
-      ListPageWithPrefixes<GoogleCloudStorageObject> gcsList = api.getObjectApi().listObjects(container);
-      PageSet<? extends StorageMetadata> list = objectListToStorageMetadata.apply(gcsList);
-      return list;
+      return list(container, ListContainerOptions.NONE);
    }
 
    @Override
    public PageSet<? extends StorageMetadata> list(String container, ListContainerOptions options) {
-      if (options != null && options != ListContainerOptions.NONE) {
-         ListObjectOptions listOptions = listContainerOptionsToListObjectOptions.apply(options);
-         ListPageWithPrefixes<GoogleCloudStorageObject> gcsList = api.getObjectApi().listObjects(container, listOptions);
-         PageSet<? extends StorageMetadata> list = objectListToStorageMetadata.apply(gcsList);
-         return options.isDetailed() ? fetchBlobMetadataProvider.get().setContainerName(container).apply(list) : list;
-      } else {
-         return list(container);
-      }
+      ListObjectOptions listOptions = listContainerOptionsToListObjectOptions.apply(options);
+      ListPageWithPrefixes<GoogleCloudStorageObject> gcsList = api.getObjectApi().listObjects(container, listOptions);
+      PageSet<? extends StorageMetadata> list = objectListToStorageMetadata.apply(gcsList);
+      return options.isDetailed() ? fetchBlobMetadataProvider.get().setContainerName(container).apply(list) : list;
    }
 
    /**

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/functions/BlobStoreListContainerOptionsToListObjectOptions.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/functions/BlobStoreListContainerOptionsToListObjectOptions.java
@@ -26,17 +26,26 @@ import com.google.common.base.Function;
 public class BlobStoreListContainerOptionsToListObjectOptions implements
          Function<ListContainerOptions, ListObjectOptions> {
    public ListObjectOptions apply(ListContainerOptions from) {
+      if (from.getDir() != null && (from.getPrefix() != null || from.getDelimiter() != null)) {
+         throw new IllegalArgumentException("Cannot pass both directory and prefix/delimiter");
+      }
       checkNotNull(from, "set options to instance NONE instead of passing null");
       ListObjectOptions httpOptions = new ListObjectOptions();
 
-      if (!from.isRecursive()) {
+      if (!from.isRecursive() && from.getDelimiter() == null) {
          httpOptions = httpOptions.delimiter("/");
+      }
+      if (from.getDelimiter() != null) {
+         httpOptions = httpOptions.delimiter(from.getDelimiter());
       }
       if (from.getDir() != null) {
          String path = from.getDir();
          if (!path.endsWith("/"))
             path += "/";
          httpOptions = httpOptions.prefix(path);
+      }
+      if (from.getPrefix() != null) {
+         httpOptions.prefix(from.getPrefix());
       }
       if (from.getMarker() != null) {
          httpOptions = httpOptions.pageToken(from.getMarker());

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/functions/ObjectToBlobMetadata.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/functions/ObjectToBlobMetadata.java
@@ -16,12 +16,10 @@
  */
 package org.jclouds.googlecloudstorage.blobstore.functions;
 
-import javax.inject.Inject;
 
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
-import org.jclouds.blobstore.strategy.IfDirectoryReturnNameStrategy;
 import org.jclouds.googlecloudstorage.domain.GoogleCloudStorageObject;
 import org.jclouds.javax.annotation.Nullable;
 
@@ -30,11 +28,6 @@ import com.google.common.hash.HashCode;
 import com.google.common.io.BaseEncoding;
 
 public class ObjectToBlobMetadata implements Function<GoogleCloudStorageObject, MutableBlobMetadata> {
-   private final IfDirectoryReturnNameStrategy ifDirectoryReturnName;
-
-   @Inject public ObjectToBlobMetadata(IfDirectoryReturnNameStrategy ifDirectoryReturnName) {
-      this.ifDirectoryReturnName = ifDirectoryReturnName;
-   }
 
    public MutableBlobMetadata apply(GoogleCloudStorageObject from) {
       if (from == null) {
@@ -55,14 +48,7 @@ public class ObjectToBlobMetadata implements Function<GoogleCloudStorageObject, 
       to.setUri(from.selfLink());
       to.setId(from.id());
       to.setPublicUri(from.mediaLink());
-
-      String directoryName = ifDirectoryReturnName.execute(to);
-      if (directoryName != null) {
-         to.setName(directoryName);
-         to.setType(StorageType.RELATIVE_PATH);
-      } else {
-         to.setType(StorageType.BLOB);
-      }
+      to.setType(StorageType.BLOB);
       to.setSize(from.size());
       return to;
    }

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerIntegrationLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerIntegrationLiveTest.java
@@ -97,7 +97,8 @@ public class GoogleCloudStorageContainerIntegrationLiveTest extends BaseContaine
 
    @Override
    public void testDirectory() throws InterruptedException {
-      // GoogleCloudStorage does not support directories, rather it supports prefixes which look like directories.
+      // TODO: testDirectory fails when querying blob with name "directory/directory"; querying "directory%2Fdirectory"
+      // succeeds, however. I believe this is an escaping issue that should be addressed.
       throw new SkipException("directories are not supported in GoogleCloudStorage");
    }
 

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerIntegrationLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageContainerIntegrationLiveTest.java
@@ -105,14 +105,4 @@ public class GoogleCloudStorageContainerIntegrationLiveTest extends BaseContaine
    public void testListMarkerAfterLastKey() throws Exception {
       throw new SkipException("cannot specify arbitrary markers");
    }
-
-   @Override
-   public void testContainerListWithPrefix() {
-      throw new SkipException("Prefix option has not been plumbed down to GCS");
-   }
-
-   @Override
-   public void testDelimiterList() {
-      throw new SkipException("Prefix option has not been plumbed down to GCS");
-   }
 }


### PR DESCRIPTION
Changes the Google storage provider to be inline with the other
providers in not returning RELATIVE_PATH for objects that are BLOBs.