### PR TITLE
JCLOUDS-1008: Use @Encoded with GCS.

### DIFF
--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectAccessControlsApi.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectAccessControlsApi.java
@@ -23,6 +23,7 @@ import java.util.List;
 import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -41,7 +42,6 @@ import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.PATCH;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.SelectJson;
-import org.jclouds.rest.annotations.SkipEncoding;
 import org.jclouds.rest.binders.BindToJsonPayload;
 
 /**
@@ -49,7 +49,6 @@ import org.jclouds.rest.binders.BindToJsonPayload;
  *
  * @see <a href = " https://developers.google.com/storage/docs/json_api/v1/objectAccessControls "/>
  */
-@SkipEncoding({ '/', '=' })
 @RequestFilters(OAuthFilter.class)
 @Consumes(APPLICATION_JSON)
 public interface ObjectAccessControlsApi {
@@ -74,7 +73,7 @@ public interface ObjectAccessControlsApi {
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    ObjectAccessControls getObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName, @PathParam("entity") String entity);
+            @PathParam("object") @Encoded String objectName, @PathParam("entity") String entity);
 
    /**
     * Returns the acl entry for the specified entity on the specified object.
@@ -97,7 +96,7 @@ public interface ObjectAccessControlsApi {
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    ObjectAccessControls getObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName, @PathParam("entity") String entity,
+            @PathParam("object") @Encoded String objectName, @PathParam("entity") String entity,
             @QueryParam("generation") Long generation);
 
    /**
@@ -116,7 +115,7 @@ public interface ObjectAccessControlsApi {
    @Produces(APPLICATION_JSON)
    @Path("/b/{bucket}/o/{object}/acl")
    ObjectAccessControls createObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName,
+            @PathParam("object") @Encoded String objectName,
             @BinderParam(BindToJsonPayload.class) ObjectAccessControlsTemplate template);
 
    /**
@@ -137,7 +136,7 @@ public interface ObjectAccessControlsApi {
    @Produces(APPLICATION_JSON)
    @Path("/b/{bucket}/o/{object}/acl")
    ObjectAccessControls createObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName,
+            @PathParam("object") @Encoded String objectName,
             @BinderParam(BindToJsonPayload.class) ObjectAccessControlsTemplate template,
             @QueryParam("generation") Long generation);
 
@@ -155,8 +154,8 @@ public interface ObjectAccessControlsApi {
    @Named("ObjectAccessControls:delete")
    @DELETE
    @Path("/b/{bucket}/o/{object}/acl/{entity}")
-   void deleteObjectAccessControls(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-            @PathParam("entity") String entity);
+   void deleteObjectAccessControls(@PathParam("bucket") String bucketName,
+         @PathParam("object") @Encoded String objectName, @PathParam("entity") String entity);
 
    /**
     * Permanently deletes the acl entry for the specified entity on the specified bucket.
@@ -174,8 +173,9 @@ public interface ObjectAccessControlsApi {
    @Named("ObjectAccessControls:delete")
    @DELETE
    @Path("/b/{bucket}/o/{object}/acl/{entity}")
-   void deleteObjectAccessControls(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-            @PathParam("entity") String entity, @QueryParam("generation") Long generation);
+   void deleteObjectAccessControls(@PathParam("bucket") String bucketName,
+         @PathParam("object") @Encoded String objectName, @PathParam("entity") String entity,
+         @QueryParam("generation") Long generation);
 
    /**
     * Retrieves acl entries on a specified object
@@ -193,7 +193,7 @@ public interface ObjectAccessControlsApi {
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    List<ObjectAccessControls> listObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName);
+            @PathParam("object") @Encoded String objectName);
 
    /**
     * Retrieves acl entries on a specified object
@@ -214,7 +214,7 @@ public interface ObjectAccessControlsApi {
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    List<ObjectAccessControls> listObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName, @QueryParam("generation") Long generation);
+            @PathParam("object") @Encoded String objectName, @QueryParam("generation") Long generation);
 
    /**
     * Updates an acl entry on the specified object
@@ -237,7 +237,7 @@ public interface ObjectAccessControlsApi {
    @Produces(APPLICATION_JSON)
    @Path("/b/{bucket}/o/{object}/acl/{entity}")
    ObjectAccessControls updateObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName, @PathParam("entity") String entity,
+            @PathParam("object") @Encoded String objectName, @PathParam("entity") String entity,
             @BinderParam(BindToJsonPayload.class) ObjectAccessControlsTemplate template);
 
    /**
@@ -262,7 +262,7 @@ public interface ObjectAccessControlsApi {
    @Produces(APPLICATION_JSON)
    @Path("/b/{bucket}/o/{object}/acl/{entity}")
    ObjectAccessControls updateObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName, @PathParam("entity") String entity,
+            @PathParam("object") @Encoded String objectName, @PathParam("entity") String entity,
             @BinderParam(BindToJsonPayload.class) ObjectAccessControlsTemplate template,
             @QueryParam("generation") Long generation);
 
@@ -286,7 +286,7 @@ public interface ObjectAccessControlsApi {
    @Produces(APPLICATION_JSON)
    @Path("/b/{bucket}/o/{object}/acl/{entity}")
    ObjectAccessControls patchObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName, @PathParam("entity") String entity,
+            @PathParam("object") @Encoded String objectName, @PathParam("entity") String entity,
             @BinderParam(BindToJsonPayload.class) ObjectAccessControlsTemplate template);
 
    /**
@@ -311,7 +311,7 @@ public interface ObjectAccessControlsApi {
    @Produces(APPLICATION_JSON)
    @Path("/b/{bucket}/o/{object}/acl/{entity}")
    ObjectAccessControls patchObjectAccessControls(@PathParam("bucket") String bucketName,
-            @PathParam("object") String objectName, @PathParam("entity") String entity,
+            @PathParam("object") @Encoded String objectName, @PathParam("entity") String entity,
             @BinderParam(BindToJsonPayload.class) ObjectAccessControlsTemplate template,
             @QueryParam("generation") Long generation);
 }

--- a/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
+++ b/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/features/ObjectApi.java
@@ -21,6 +21,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -60,7 +61,6 @@ import org.jclouds.rest.annotations.PayloadParam;
 import org.jclouds.rest.annotations.QueryParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
-import org.jclouds.rest.annotations.SkipEncoding;
 import org.jclouds.rest.binders.BindToJsonPayload;
 
 /**
@@ -68,7 +68,6 @@ import org.jclouds.rest.binders.BindToJsonPayload;
  *
  * @see <a href="https://developers.google.com/storage/docs/json_api/v1/objects"/>
  */
-@SkipEncoding({ '/', '=' })
 @RequestFilters(OAuthFilter.class)
 public interface ObjectApi {
 
@@ -87,7 +86,7 @@ public interface ObjectApi {
    @Path("storage/v1/b/{bucket}/o/{object}")
    @Fallback(FalseOnNotFoundOr404.class)
    @Nullable
-   boolean objectExists(@PathParam("bucket") String bucketName, @PathParam("object") String objectName);
+   boolean objectExists(@PathParam("bucket") String bucketName, @PathParam("object") @Encoded String objectName);
 
    /**
     * Retrieve an object metadata
@@ -105,7 +104,8 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
-   GoogleCloudStorageObject getObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName);
+   GoogleCloudStorageObject getObject(@PathParam("bucket") String bucketName,
+         @PathParam("object") @Encoded String objectName);
 
    /**
     * Retrieves objects metadata
@@ -126,8 +126,8 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
-   GoogleCloudStorageObject getObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-         HttpRequestOptions options);
+   GoogleCloudStorageObject getObject(@PathParam("bucket") String bucketName,
+         @PathParam("object") @Encoded String objectName, HttpRequestOptions options);
 
    /**
     * Retrieve an object or their metadata
@@ -146,7 +146,7 @@ public interface ObjectApi {
    @ResponseParser(ParseToPayloadEnclosing.class)
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
-   PayloadEnclosing download(@PathParam("bucket") String bucketName, @PathParam("object") String objectName);
+   PayloadEnclosing download(@PathParam("bucket") String bucketName, @PathParam("object") @Encoded String objectName);
 
    /**
     * Retrieves objects
@@ -167,7 +167,8 @@ public interface ObjectApi {
    @Path("storage/v1/b/{bucket}/o/{object}")
    @ResponseParser(ParseToPayloadEnclosing.class)
    @Fallback(NullOnNotFoundOr404.class)
-   @Nullable PayloadEnclosing download(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
+   @Nullable
+   PayloadEnclosing download(@PathParam("bucket") String bucketName, @PathParam("object") @Encoded String objectName,
          HttpRequestOptions options);
 
    /**
@@ -204,7 +205,7 @@ public interface ObjectApi {
    @DELETE
    @Path("storage/v1/b/{bucket}/o/{object}")
    @Fallback(FalseOnNotFoundOr404.class)
-   boolean deleteObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName);
+   boolean deleteObject(@PathParam("bucket") String bucketName, @PathParam("object") @Encoded String objectName);
 
    /**
     * Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the
@@ -221,7 +222,7 @@ public interface ObjectApi {
    @DELETE
    @Path("storage/v1/b/{bucket}/o/{object}")
    @Fallback(FalseOnNotFoundOr404.class)
-   boolean deleteObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
+   boolean deleteObject(@PathParam("bucket") String bucketName, @PathParam("object") @Encoded String objectName,
             DeleteObjectOptions options);
 
    /**
@@ -271,8 +272,9 @@ public interface ObjectApi {
    @Produces(APPLICATION_JSON)
    @Path("storage/v1/b/{bucket}/o/{object}")
    @Fallback(NullOnNotFoundOr404.class)
-   GoogleCloudStorageObject updateObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-            @BinderParam(BindToJsonPayload.class) ObjectTemplate objectTemplate);
+   GoogleCloudStorageObject updateObject(@PathParam("bucket") String bucketName,
+         @PathParam("object") @Encoded String objectName,
+         @BinderParam(BindToJsonPayload.class) ObjectTemplate objectTemplate);
 
    /**
     * Updates an object
@@ -294,8 +296,9 @@ public interface ObjectApi {
    @Produces(APPLICATION_JSON)
    @Path("storage/v1/b/{bucket}/o/{object}")
    @Fallback(NullOnNotFoundOr404.class)
-   GoogleCloudStorageObject updateObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-            @BinderParam(BindToJsonPayload.class) ObjectTemplate objectTemplate, UpdateObjectOptions options);
+   GoogleCloudStorageObject updateObject(@PathParam("bucket") String bucketName,
+         @PathParam("object") @Encoded String objectName,
+         @BinderParam(BindToJsonPayload.class) ObjectTemplate objectTemplate, UpdateObjectOptions options);
 
    /**
     * Updates an object according to patch semantics
@@ -315,8 +318,9 @@ public interface ObjectApi {
    @Produces(APPLICATION_JSON)
    @Path("storage/v1/b/{bucket}/o/{object}")
    @Fallback(NullOnNotFoundOr404.class)
-   GoogleCloudStorageObject patchObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-            @BinderParam(BindToJsonPayload.class) ObjectTemplate objectTemplate);
+   GoogleCloudStorageObject patchObject(@PathParam("bucket") String bucketName,
+         @PathParam("object") @Encoded String objectName,
+         @BinderParam(BindToJsonPayload.class) ObjectTemplate objectTemplate);
 
    /**
     * Updates an object according to patch semantics
@@ -338,8 +342,9 @@ public interface ObjectApi {
    @Produces(APPLICATION_JSON)
    @Path("storage/v1/b/{bucket}/o/{object}")
    @Fallback(NullOnNotFoundOr404.class)
-   GoogleCloudStorageObject patchObject(@PathParam("bucket") String bucketName, @PathParam("object") String objectName,
-            @BinderParam(BindToJsonPayload.class) ObjectTemplate objectTemplate, UpdateObjectOptions options);
+   GoogleCloudStorageObject patchObject(@PathParam("bucket") String bucketName,
+         @PathParam("object") @Encoded String objectName,
+         @BinderParam(BindToJsonPayload.class) ObjectTemplate objectTemplate, UpdateObjectOptions options);
 
    /**
     * Concatenates a list of existing objects into a new object in the same bucket.
@@ -358,7 +363,7 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Path("storage/v1/b/{destinationBucket}/o/{destinationObject}/compose")
    GoogleCloudStorageObject composeObjects(@PathParam("destinationBucket") String destinationBucket,
-            @PathParam("destinationObject") String destinationObject,
+            @PathParam("destinationObject") @Encoded String destinationObject,
             @BinderParam(BindToJsonPayload.class) ComposeObjectTemplate composeObjectTemplate);
 
    /**
@@ -380,7 +385,7 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Path("storage/v1/b/{destinationBucket}/o/{destinationObject}/compose")
    GoogleCloudStorageObject composeObjects(@PathParam("destinationBucket") String destinationBucket,
-            @PathParam("destinationObject") String destinationObject,
+            @PathParam("destinationObject") @Encoded String destinationObject,
             @BinderParam(BindToJsonPayload.class) ComposeObjectTemplate composeObjectTemplate,
             ComposeObjectOptions options);
 
@@ -403,8 +408,9 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Path("/storage/v1/b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}")
    GoogleCloudStorageObject copyObject(@PathParam("destinationBucket") String destinationBucket,
-            @PathParam("destinationObject") String destinationObject, @PathParam("sourceBucket") String sourceBucket,
-            @PathParam("sourceObject") String sourceObject);
+         @PathParam("destinationObject") @Encoded String destinationObject,
+         @PathParam("sourceBucket") String sourceBucket,
+         @PathParam("sourceObject") @Encoded String sourceObject);
 
     /**
      * Copies an object to a specified location with updated metadata.
@@ -427,8 +433,10 @@ public interface ObjectApi {
     @Consumes(APPLICATION_JSON)
     @Path("/storage/v1/b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}")
     GoogleCloudStorageObject copyObject(@PathParam("destinationBucket") String destinationBucket,
-                                        @PathParam("destinationObject") String destinationObject, @PathParam("sourceBucket") String sourceBucket,
-                                        @PathParam("sourceObject") String sourceObject, @BinderParam(BindToJsonPayload.class) ObjectTemplate template);
+          @PathParam("destinationObject") @Encoded String destinationObject,
+          @PathParam("sourceBucket") String sourceBucket,
+          @PathParam("sourceObject") @Encoded String sourceObject,
+          @BinderParam(BindToJsonPayload.class) ObjectTemplate template);
 
    /**
     * Copies an object to a specified location. Optionally overrides metadata.
@@ -451,8 +459,9 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Path("/storage/v1/b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}")
    GoogleCloudStorageObject copyObject(@PathParam("destinationBucket") String destinationBucket,
-            @PathParam("destinationObject") String destinationObject, @PathParam("sourceBucket") String sourceBucket,
-            @PathParam("sourceObject") String sourceObject, CopyObjectOptions options);
+         @PathParam("destinationObject") @Encoded String destinationObject,
+         @PathParam("sourceBucket") String sourceBucket,
+         @PathParam("sourceObject") @Encoded String sourceObject, CopyObjectOptions options);
 
    /**
     * Stores a new object with metadata.
@@ -495,9 +504,8 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Path("/storage/v1/b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}")
    RewriteResponse rewriteObjects(@PathParam("destinationBucket") String destinationBucket,
-            @PathParam("destinationObject") String destinationObject,
-            @PathParam("sourceBucket") String sourceBucket,
-            @PathParam("sourceObject") String sourceObject);
+         @PathParam("destinationObject") @Encoded String destinationObject,
+         @PathParam("sourceBucket") String sourceBucket, @PathParam("sourceObject") @Encoded String sourceObject);
 
    /**
     * Rewrites a source object to a destination object.
@@ -520,8 +528,8 @@ public interface ObjectApi {
    @Consumes(APPLICATION_JSON)
    @Path("/storage/v1/b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}")
    RewriteResponse rewriteObjects(@PathParam("destinationBucket") String destinationBucket,
-            @PathParam("destinationObject") String destinationObject,
-            @PathParam("sourceBucket") String sourceBucket,
-            @PathParam("sourceObject") String sourceObject,
-            RewriteObjectOptions options);
+         @PathParam("destinationObject") @Encoded String destinationObject,
+         @PathParam("sourceBucket") String sourceBucket,
+         @PathParam("sourceObject") @Encoded String sourceObject,
+         RewriteObjectOptions options);
 }

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageBlobIntegrationLiveTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/blobstore/integration/GoogleCloudStorageBlobIntegrationLiveTest.java
@@ -143,6 +143,7 @@ public class GoogleCloudStorageBlobIntegrationLiveTest extends BaseBlobIntegrati
 
       return new Object[][] { { "file.xml", "text/xml", file, realObject },
                { "string.xml", "text/xml", realObject, realObject },
+               { "stringwith/slash.xml", "text/xml", realObject, realObject },
                { "bytes.xml", "application/octet-stream", realObject.getBytes(), realObject } };
    }
 

--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
@@ -40,6 +40,7 @@ import org.jclouds.googlecloudstorage.parse.ParseGoogleCloudStorageObjectListTes
 import org.jclouds.googlecloudstorage.parse.ParseObjectRewriteResponse;
 import org.jclouds.http.internal.PayloadEnclosingImpl;
 import org.jclouds.io.PayloadEnclosing;
+import org.jclouds.util.Strings2;
 import org.testng.annotations.Test;
 
 import com.google.common.net.MediaType;
@@ -55,6 +56,13 @@ public class ObjectApiMockTest extends BaseGoogleCloudStorageApiMockTest {
 
       assertTrue(objectApi().objectExists("test", "file_name"));
       assertSent(server, "GET", "/storage/v1/b/test/o/file_name", null);
+   }
+
+   public void existsEncoded() throws Exception {
+      server.enqueue(jsonResponse("/object_encoded_get.json"));
+
+      assertTrue(objectApi().objectExists("test", Strings2.urlEncode("dir/file name")));
+      assertSent(server, "GET", "/storage/v1/b/test/o/dir%2Ffile%20name", null);
    }
 
    public void exists_4xx() throws Exception {
@@ -118,6 +126,14 @@ public class ObjectApiMockTest extends BaseGoogleCloudStorageApiMockTest {
       // TODO: Should this be returning True on not found?
       assertTrue(objectApi().deleteObject("test", "object_name"));
       assertSent(server, "DELETE", "/storage/v1/b/test/o/object_name", null);
+   }
+
+   public void delete_encoded() throws Exception {
+      server.enqueue(new MockResponse());
+
+      // TODO: Should this be returning True on not found?
+      assertTrue(objectApi().deleteObject("test", Strings2.urlEncode("dir/object name")));
+      assertSent(server, "DELETE", "/storage/v1/b/test/o/dir%2Fobject%20name", null);
    }
 
    public void list() throws Exception {

--- a/google-cloud-storage/src/test/resources/object_encoded_get.json
+++ b/google-cloud-storage/src/test/resources/object_encoded_get.json
@@ -1,0 +1,21 @@
+{
+  "kind": "storage#object",
+  "id": "test/dir%2Ffile%20name/1000",
+  "selfLink": "https://www.googleapis.com/storage/v1/b/test/o/dir%2Ffile%20name",
+  "name": "dir%2Ffile%20name",
+  "bucket": "test",
+  "generation": "1000",
+  "metageneration": "8",
+  "contentType": "application/x-tar",
+  "updated": "2014-09-27T00:01:44.819",
+  "storageClass": "STANDARD",
+  "size": "1000",
+  "md5Hash": "md5Hash",
+  "mediaLink": "https://www.googleapis.com/download/storage/v1/b/test/o/dir%2Ffile%20name?generation=1000&alt=media",
+  "owner": {
+    "entity": "entity",
+    "entityId": "entityId"
+  },
+  "crc32c": "crc32c",
+  "etag": "etag"
+}


### PR DESCRIPTION
Google cloud storage should use the @Encoded annotation with the
object names to make sure that the object is percent-encoded prior to
being submitted in the path of the request. This was previously broken
because the default path encoding ignores "/" and encodes the entire
string. The @Encoded decorator allows jclouds rest annotation
processor to encode the values being placed in the path instead.

Requires https://github.com/jclouds/jclouds/pull/861 to be merged.