### PR TITLE
Support shortened hardwareId in GCE

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
@@ -41,6 +41,7 @@ import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.OperatingSystem;
 import org.jclouds.compute.domain.OsFamily;
+import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.compute.extensions.ImageExtension;
 import org.jclouds.compute.extensions.SecurityGroupExtension;
 import org.jclouds.compute.options.TemplateOptions;
@@ -58,6 +59,7 @@ import org.jclouds.googlecomputeengine.compute.functions.InstanceToNodeMetadata;
 import org.jclouds.googlecomputeengine.compute.functions.MachineTypeToHardware;
 import org.jclouds.googlecomputeengine.compute.functions.OrphanedGroupsFromDeadNodes;
 import org.jclouds.googlecomputeengine.compute.functions.Resources;
+import org.jclouds.googlecomputeengine.compute.internal.GCETemplateBuilderImpl;
 import org.jclouds.googlecomputeengine.compute.options.GoogleComputeEngineTemplateOptions;
 import org.jclouds.googlecomputeengine.compute.predicates.GroupIsEmpty;
 import org.jclouds.googlecomputeengine.compute.predicates.AtomicInstanceVisible;
@@ -119,12 +121,14 @@ public final class GoogleComputeEngineServiceContextModule
 
       bind(TemplateOptions.class).to(GoogleComputeEngineTemplateOptions.class);
 
+      bind(TemplateBuilder.class).to(GCETemplateBuilderImpl.class);
+
       bind(new TypeLiteral<Function<Set<? extends NodeMetadata>, Set<String>>>() {
       }).to(OrphanedGroupsFromDeadNodes.class);
 
       bind(new TypeLiteral<Predicate<String>>() {
       }).to(GroupIsEmpty.class);
-      
+
       bind(new TypeLiteral<Function<String, OperatingSystem>>() {
       }).to(ImageNameToOperatingSystem.class);
 
@@ -179,7 +183,7 @@ public final class GoogleComputeEngineServiceContextModule
          }
       }, seconds, SECONDS);
    }
-   
+
    @Override
    protected Map<OsFamily, LoginCredentials> osFamilyToCredentials(Injector injector) {
       // GCE does not enable the 'root' account for ssh access by default, but it will create a privileged

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/internal/GCETemplateBuilderImpl.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/internal/GCETemplateBuilderImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.compute.internal;
+
+import com.google.common.base.Supplier;
+import org.jclouds.collect.Memoized;
+import org.jclouds.compute.domain.Hardware;
+import org.jclouds.compute.domain.TemplateBuilder;
+import org.jclouds.compute.domain.internal.TemplateBuilderImpl;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.compute.strategy.GetImageStrategy;
+import org.jclouds.compute.suppliers.ImageCacheSupplier;
+import org.jclouds.domain.Location;
+import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import java.util.Set;
+
+public class GCETemplateBuilderImpl extends TemplateBuilderImpl {
+    private final String projectSelfLink;
+
+    @Inject
+    protected GCETemplateBuilderImpl(@Memoized Supplier<Set<? extends Location>> locations, ImageCacheSupplier images,
+                                     @Memoized Supplier<Set<? extends Hardware>> hardwares, Supplier<Location> defaultLocation,
+                                     @Named("DEFAULT") Provider<TemplateOptions> optionsProvider, @Named("DEFAULT") Provider<TemplateBuilder> defaultTemplateProvider,
+                                     GetImageStrategy getImageStrategy, GoogleComputeEngineApi api) {
+        super(locations, images, hardwares, defaultLocation, optionsProvider, defaultTemplateProvider, getImageStrategy);
+        projectSelfLink = api.project().get().selfLink().toString();
+    }
+
+    @Override
+    public TemplateBuilder hardwareId(String hardwareId) {
+        if (!hardwareId.startsWith("https://") ) {
+            if (location == null) {
+                throw new IllegalStateException("GCE: first set locationId and then you can use shortened hardwareId");
+            }
+            hardwareId = projectSelfLink + "/zones/" + location.getId() + "/machineTypes/" + hardwareId;
+        }
+        super.hardwareId(hardwareId);
+        return this;
+    }
+}


### PR DESCRIPTION
Ability to use short names for hardwareId like:
   n1-standard-1
   n1-standard-2
   ...

https://cloud.google.com/compute/docs/machine-types#standard_machine_types

I tested it with [Apache Brooklyn](https://brooklyn.apache.org) and it works.
