### PR TITLE
Do not leave open streams when loading test mock files

### DIFF
--- a/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/internal/BaseGoogleCloudStorageExpectTest.java
+++ b/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/internal/BaseGoogleCloudStorageExpectTest.java
@@ -49,14 +49,16 @@ import org.jclouds.googlecloudstorage.GoogleCloudStorageProviderMetadata;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.io.Payload;
-import org.jclouds.io.payloads.ByteSourcePayload;
+import org.jclouds.io.Payloads;
 import org.jclouds.oauth.v2.filters.JWTBearerTokenFlow;
 import org.jclouds.oauth.v2.filters.TestJWTBearerTokenFlow;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.rest.internal.BaseRestApiExpectTest;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Resources;
 import com.google.inject.Binder;
@@ -167,6 +169,10 @@ public class BaseGoogleCloudStorageExpectTest<T> extends BaseRestApiExpectTest<T
    }
 
    protected Payload staticPayloadFromResource(String resource) {
-      return new ByteSourcePayload(Resources.asByteSource(Resources.getResource(getClass(), resource)));
+      try {
+         return Payloads.newStringPayload(Resources.toString(Resources.getResource(getClass(), resource), Charsets.UTF_8));
+      } catch (IOException ex) {
+         throw Throwables.propagate(ex);
+      }
    }
 }


### PR DESCRIPTION
In commit https://github.com/jclouds/jclouds/commit/a43acaffce0cc04e05c15c55bd94cadcd55843f1 we changed how streams were treated when deserializing objects, delegating to the caller the responsibility to properly close the streams.

This change changes how the response payloads were generated. Since the expect tests don't use the base command executor service but just invoke directly the methods and deserialize the responses, the lifecycle of the streams used to read the files was not properly managed.